### PR TITLE
locked canon version to `0.1.3`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ogc-gml.gemspec
 gemspec
 
-gem "canon"
+gem "canon", "=0.1.3"
 gem "lutaml-model", github: "lutaml/lutaml-model", branch: "main"
 gem "rake"
 gem "rspec"


### PR DESCRIPTION
Fixes failing tests in Lutaml::Model -> https://github.com/lutaml/lutaml-model/actions/runs/20617766682/job/59213865362
Locked `canon` version to `0.1.3`