### PR TITLE
refactor: replace require graph with autoload, fixes #21

### DIFF
--- a/lib/ogc/gml.rb
+++ b/lib/ogc/gml.rb
@@ -11,330 +11,666 @@ require_relative "gml/version"
 module Ogc
   module Gml
     class Error < StandardError; end
+
+    autoload :AbstractCRS,
+             "ogc/gml/abstract_crs"
+    autoload :AbstractContinuousCoverage,
+             "ogc/gml/abstract_continuous_coverage"
+    autoload :AbstractCoordinateOperation,
+             "ogc/gml/abstract_coordinate_operation"
+    autoload :AbstractCoordinateSystem,
+             "ogc/gml/abstract_coordinate_system"
+    autoload :AbstractCoverage,
+             "ogc/gml/abstract_coverage"
+    autoload :AbstractCurve,
+             "ogc/gml/abstract_curve"
+    autoload :AbstractCurveSegment,
+             "ogc/gml/abstract_curve_segment"
+    autoload :AbstractDatum,
+             "ogc/gml/abstract_datum"
+    autoload :AbstractFeature,
+             "ogc/gml/abstract_feature"
+    autoload :AbstractFeatureCollection,
+             "ogc/gml/abstract_feature_collection"
+    autoload :AbstractGML,
+             "ogc/gml/abstract_gml"
+    autoload :AbstractGeneralConversion,
+             "ogc/gml/abstract_general_conversion"
+    autoload :AbstractGeneralDerivedCRS,
+             "ogc/gml/abstract_general_derived_crs"
+    autoload :AbstractGeneralOperationParameter,
+             "ogc/gml/abstract_general_operation_parameter"
+    autoload :AbstractGeneralOperationParameterProperty,
+             "ogc/gml/abstract_general_operation_parameter_property"
+    autoload :AbstractGeneralParameterValue,
+             "ogc/gml/abstract_general_parameter_value"
+    autoload :AbstractGeneralParameterValueProperty,
+             "ogc/gml/abstract_general_parameter_value_property"
+    autoload :AbstractGeneralTransformation,
+             "ogc/gml/abstract_general_transformation"
+    autoload :AbstractGeometricAggregate,
+             "ogc/gml/abstract_geometric_aggregate"
+    autoload :AbstractGeometricPrimitive,
+             "ogc/gml/abstract_geometric_primitive"
+    autoload :AbstractGeometry,
+             "ogc/gml/abstract_geometry"
+    autoload :AbstractGriddedSurface,
+             "ogc/gml/abstract_gridded_surface"
+    autoload :AbstractMetaData,
+             "ogc/gml/abstract_meta_data"
+    autoload :AbstractParametricCurveSurface,
+             "ogc/gml/abstract_parametric_curve_surface"
+    autoload :AbstractRing,
+             "ogc/gml/abstract_ring"
+    autoload :AbstractRingProperty,
+             "ogc/gml/abstract_ring_property"
+    autoload :AbstractSolid,
+             "ogc/gml/abstract_solid"
+    autoload :AbstractSurface,
+             "ogc/gml/abstract_surface"
+    autoload :AbstractSurfacePatch,
+             "ogc/gml/abstract_surface_patch"
+    autoload :AbstractTimeComplex,
+             "ogc/gml/abstract_time_complex"
+    autoload :AbstractTimeGeometricPrimitive,
+             "ogc/gml/abstract_time_geometric_primitive"
+    autoload :AbstractTimeObject,
+             "ogc/gml/abstract_time_object"
+    autoload :AbstractTimePrimitive,
+             "ogc/gml/abstract_time_primitive"
+    autoload :AbstractTimeSlice,
+             "ogc/gml/abstract_time_slice"
+    autoload :AbstractTimeTopologyPrimitive,
+             "ogc/gml/abstract_time_topology_primitive"
+    autoload :AbstractTopoPrimitive,
+             "ogc/gml/abstract_topo_primitive"
+    autoload :AbstractTopology,
+             "ogc/gml/abstract_topology"
+    autoload :AffineCS,
+             "ogc/gml/affine_cs"
+    autoload :AffineCSProperty,
+             "ogc/gml/affine_cs_property"
+    autoload :AffinePlacement,
+             "ogc/gml/affine_placement"
+    autoload :AggregationType,
+             "ogc/gml/dictionary"
+    autoload :Angle,
+             "ogc/gml/angle"
+    autoload :Arc,
+             "ogc/gml/arc"
+    autoload :ArcByBulge,
+             "ogc/gml/arc_by_bulge"
+    autoload :ArcByCenterPoint,
+             "ogc/gml/arc_by_center_point"
+    autoload :ArcString,
+             "ogc/gml/arc_string"
+    autoload :ArcStringByBulge,
+             "ogc/gml/arc_string_by_bulge"
+    autoload :Array,
+             "ogc/gml/array"
+    autoload :ArrayAssociation,
+             "ogc/gml/array_association"
+    autoload :AssociationRole,
+             "ogc/gml/association_role"
+    autoload :BSpline,
+             "ogc/gml/b_spline"
+    autoload :Bag,
+             "ogc/gml/bag"
+    autoload :BaseUnit,
+             "ogc/gml/base_unit"
+    autoload :Bezier,
+             "ogc/gml/bezier"
+    autoload :Boolean,
+             "ogc/gml/boolean"
+    autoload :BoundingShape,
+             "ogc/gml/bounding_shape"
+    autoload :CRSProperty,
+             "ogc/gml/crs_property"
+    autoload :CartesianCS,
+             "ogc/gml/cartesian_cs"
+    autoload :CartesianCSProperty,
+             "ogc/gml/cartesian_cs_property"
+    autoload :Category,
+             "ogc/gml/category"
+    autoload :CategoryExtent,
+             "ogc/gml/category_extent"
+    autoload :Circle,
+             "ogc/gml/circle"
+    autoload :CircleByCenterPoint,
+             "ogc/gml/circle_by_center_point"
+    autoload :Clothoid,
+             "ogc/gml/clothoid"
+    autoload :Code,
+             "ogc/gml/code"
+    autoload :CodeOrNilReasonList,
+             "ogc/gml/code_or_nil_reason_list"
+    autoload :CodeWithAuthority,
+             "ogc/gml/code_with_authority"
+    autoload :CompositeCurve,
+             "ogc/gml/composite_curve"
+    autoload :CompositeSolid,
+             "ogc/gml/composite_solid"
+    autoload :CompositeSurface,
+             "ogc/gml/composite_surface"
+    autoload :CompositeValue,
+             "ogc/gml/composite_value"
+    autoload :CompoundCRS,
+             "ogc/gml/compound_crs"
+    autoload :CompoundCRSProperty,
+             "ogc/gml/compound_crs_property"
+    autoload :ConcatenatedOperation,
+             "ogc/gml/concatenated_operation"
+    autoload :ConcatenatedOperationProperty,
+             "ogc/gml/concatenated_operation_property"
+    autoload :Cone,
+             "ogc/gml/cone"
+    autoload :ControlPoint,
+             "ogc/gml/control_point"
+    autoload :ConventionalUnit,
+             "ogc/gml/conventional_unit"
+    autoload :Conversion,
+             "ogc/gml/conversion"
+    autoload :ConversionProperty,
+             "ogc/gml/conversion_property"
+    autoload :ConversionToPreferredUnit,
+             "ogc/gml/conversion_to_preferred_unit"
+    autoload :CoordinateOperationAccuracy,
+             "ogc/gml/coordinate_operation_accuracy"
+    autoload :CoordinateOperationProperty,
+             "ogc/gml/coordinate_operation_property"
+    autoload :CoordinateSystemAxis,
+             "ogc/gml/coordinate_system_axis"
+    autoload :CoordinateSystemAxisProperty,
+             "ogc/gml/coordinate_system_axis_property"
+    autoload :CoordinateSystemProperty,
+             "ogc/gml/coordinate_system_property"
+    autoload :Coordinates,
+             "ogc/gml/coordinates"
+    autoload :Count,
+             "ogc/gml/count"
+    autoload :CoverageFunction,
+             "ogc/gml/coverage_function"
+    autoload :CubicSpline,
+             "ogc/gml/cubic_spline"
+    autoload :Curve,
+             "ogc/gml/curve"
+    autoload :CurveArrayProperty,
+             "ogc/gml/curve_array_property"
+    autoload :CurveProperty,
+             "ogc/gml/curve_property"
+    autoload :CurveSegmentArrayProperty,
+             "ogc/gml/curve_segment_array_property"
+    autoload :Cylinder,
+             "ogc/gml/cylinder"
+    autoload :CylindricalCS,
+             "ogc/gml/cylindrical_cs"
+    autoload :CylindricalCSProperty,
+             "ogc/gml/cylindrical_cs_property"
+    autoload :DMSAngle,
+             "ogc/gml/dms_angle"
+    autoload :DataBlock,
+             "ogc/gml/data_block"
+    autoload :DatumProperty,
+             "ogc/gml/datum_property"
+    autoload :Definition,
+             "ogc/gml/definition"
+    autoload :DefinitionProxy,
+             "ogc/gml/definition_proxy"
+    autoload :Degrees,
+             "ogc/gml/degrees"
+    autoload :DerivationUnitTerm,
+             "ogc/gml/derivation_unit_term"
+    autoload :DerivedCRS,
+             "ogc/gml/derived_crs"
+    autoload :DerivedCRSProperty,
+             "ogc/gml/derived_crs_property"
+    autoload :DerivedUnit,
+             "ogc/gml/derived_unit"
+    autoload :Dictionary,
+             "ogc/gml/dictionary"
+    autoload :DictionaryEntry,
+             "ogc/gml/dictionary_entry"
+    autoload :DirectPosition,
+             "ogc/gml/direct_position"
+    autoload :DirectPositionList,
+             "ogc/gml/direct_position_list"
+    autoload :DirectedEdgeProperty,
+             "ogc/gml/directed_edge_property"
+    autoload :DirectedFaceProperty,
+             "ogc/gml/directed_face_property"
+    autoload :DirectedNodeProperty,
+             "ogc/gml/directed_node_property"
+    autoload :DirectedObservation,
+             "ogc/gml/directed_observation"
+    autoload :DirectedObservationAtDistance,
+             "ogc/gml/directed_observation_at_distance"
+    autoload :DirectedTopoSolidProperty,
+             "ogc/gml/directed_topo_solid_property"
+    autoload :DirectionDescription,
+             "ogc/gml/direction_description"
+    autoload :DirectionProperty,
+             "ogc/gml/direction_property"
+    autoload :DirectionVector,
+             "ogc/gml/direction_vector"
+    autoload :DiscreteCoverage,
+             "ogc/gml/discrete_coverage"
+    autoload :DomainOfValidity,
+             "ogc/gml/domain_of_validity"
+    autoload :DomainSet,
+             "ogc/gml/domain_set"
+    autoload :DynamicFeature,
+             "ogc/gml/dynamic_feature"
+    autoload :DynamicFeatureCollection,
+             "ogc/gml/dynamic_feature_collection"
+    autoload :DynamicFeatureMember,
+             "ogc/gml/dynamic_feature_member"
+    autoload :Edge,
+             "ogc/gml/edge"
+    autoload :Ellipsoid,
+             "ogc/gml/ellipsoid"
+    autoload :EllipsoidProperty,
+             "ogc/gml/ellipsoid_property"
+    autoload :EllipsoidalCS,
+             "ogc/gml/ellipsoidal_cs"
+    autoload :EllipsoidalCSProperty,
+             "ogc/gml/ellipsoidal_cs_property"
+    autoload :EngineeringCRS,
+             "ogc/gml/engineering_crs"
+    autoload :EngineeringCRSProperty,
+             "ogc/gml/engineering_crs_property"
+    autoload :EngineeringDatum,
+             "ogc/gml/engineering_datum"
+    autoload :EngineeringDatumProperty,
+             "ogc/gml/engineering_datum_property"
+    autoload :Envelope,
+             "ogc/gml/envelope"
+    autoload :EnvelopeWithTimePeriod,
+             "ogc/gml/envelope_with_time_period"
+    autoload :Face,
+             "ogc/gml/face"
+    autoload :FaceOrTopoSolidProperty,
+             "ogc/gml/face_or_topo_solid_property"
+    autoload :FeatureArrayProperty,
+             "ogc/gml/feature_array_property"
+    autoload :FeatureCollection,
+             "ogc/gml/feature_collection"
+    autoload :FeatureProperty,
+             "ogc/gml/feature_property"
+    autoload :File,
+             "ogc/gml/file"
+    autoload :Formula,
+             "ogc/gml/formula"
+    autoload :FormulaCitation,
+             "ogc/gml/formula_citation"
+    autoload :GeneralConversionProperty,
+             "ogc/gml/general_conversion_property"
+    autoload :GeneralTransformationProperty,
+             "ogc/gml/general_transformation_property"
+    autoload :GenericMetaData,
+             "ogc/gml/generic_meta_data"
+    autoload :GeocentricCRS,
+             "ogc/gml/geocentric_crs"
+    autoload :GeocentricCRSProperty,
+             "ogc/gml/geocentric_crs_property"
+    autoload :Geodesic,
+             "ogc/gml/geodesic"
+    autoload :GeodesicString,
+             "ogc/gml/geodesic_string"
+    autoload :GeodeticCRS,
+             "ogc/gml/geodetic_crs"
+    autoload :GeodeticCRSProperty,
+             "ogc/gml/geodetic_crs_property"
+    autoload :GeodeticDatum,
+             "ogc/gml/geodetic_datum"
+    autoload :GeodeticDatumProperty,
+             "ogc/gml/geodetic_datum_property"
+    autoload :GeographicCRS,
+             "ogc/gml/geographic_crs"
+    autoload :GeographicCRSProperty,
+             "ogc/gml/geographic_crs_property"
+    autoload :GeometricComplex,
+             "ogc/gml/geometric_complex"
+    autoload :GeometricPrimitiveProperty,
+             "ogc/gml/geometric_primitive_property"
+    autoload :GeometryArrayProperty,
+             "ogc/gml/geometry_array_property"
+    autoload :GeometryProperty,
+             "ogc/gml/geometry_property"
+    autoload :Gml31Namespace,
+             "ogc/gml/namespaces/gml_31_namespace"
+    autoload :Gml32Namespace,
+             "ogc/gml/namespaces/gml_32_namespace"
+    autoload :Grid,
+             "ogc/gml/grid"
+    autoload :GridEnvelope,
+             "ogc/gml/grid_envelope"
+    autoload :GridFunction,
+             "ogc/gml/grid_function"
+    autoload :GridLimits,
+             "ogc/gml/grid_limits"
+    autoload :HistoryProperty,
+             "ogc/gml/history_property"
+    autoload :Identifier,
+             "ogc/gml/identifier"
+    autoload :ImageCRS,
+             "ogc/gml/image_crs"
+    autoload :ImageCRSProperty,
+             "ogc/gml/image_crs_property"
+    autoload :ImageDatum,
+             "ogc/gml/image_datum"
+    autoload :ImageDatumProperty,
+             "ogc/gml/image_datum_property"
+    autoload :IndirectEntry,
+             "ogc/gml/indirect_entry"
+    autoload :InlineProperty,
+             "ogc/gml/inline_property"
+    autoload :Knot,
+             "ogc/gml/knot"
+    autoload :KnotProperty,
+             "ogc/gml/knot_property"
+    autoload :Length,
+             "ogc/gml/length"
+    autoload :LineString,
+             "ogc/gml/line_string"
+    autoload :LineStringSegment,
+             "ogc/gml/line_string_segment"
+    autoload :LineStringSegmentArrayProperty,
+             "ogc/gml/line_string_segment_array_property"
+    autoload :LinearCS,
+             "ogc/gml/linear_cs"
+    autoload :LinearCSProperty,
+             "ogc/gml/linear_cs_property"
+    autoload :LinearRing,
+             "ogc/gml/linear_ring"
+    autoload :LocationProperty,
+             "ogc/gml/location_property"
+    autoload :MappingRule,
+             "ogc/gml/mapping_rule"
+    autoload :Measure,
+             "ogc/gml/measure"
+    autoload :MeasureList,
+             "ogc/gml/measure_list"
+    autoload :MeasureOrNilReasonList,
+             "ogc/gml/measure_or_nil_reason_list"
+    autoload :MetaDataProperty,
+             "ogc/gml/meta_data_property"
+    autoload :MovingObjectStatus,
+             "ogc/gml/moving_object_status"
+    autoload :MultiCurve,
+             "ogc/gml/multi_curve"
+    autoload :MultiCurveProperty,
+             "ogc/gml/multi_curve_property"
+    autoload :MultiGeometry,
+             "ogc/gml/multi_geometry"
+    autoload :MultiGeometryProperty,
+             "ogc/gml/multi_geometry_property"
+    autoload :MultiPoint,
+             "ogc/gml/multi_point"
+    autoload :MultiPointProperty,
+             "ogc/gml/multi_point_property"
+    autoload :MultiSolid,
+             "ogc/gml/multi_solid"
+    autoload :MultiSolidProperty,
+             "ogc/gml/multi_solid_property"
+    autoload :MultiSurface,
+             "ogc/gml/multi_surface"
+    autoload :MultiSurfaceProperty,
+             "ogc/gml/multi_surface_property"
+    autoload :Namespace,
+             "ogc/gml/namespace"
+    autoload :Node,
+             "ogc/gml/node"
+    autoload :NodeOrEdgeProperty,
+             "ogc/gml/node_or_edge_property"
+    autoload :NodeProperty,
+             "ogc/gml/node_property"
+    autoload :ObliqueCartesianCS,
+             "ogc/gml/oblique_cartesian_cs"
+    autoload :ObliqueCartesianCSProperty,
+             "ogc/gml/oblique_cartesian_cs_property"
+    autoload :Observation,
+             "ogc/gml/observation"
+    autoload :OffsetCurve,
+             "ogc/gml/offset_curve"
+    autoload :OperationMethod,
+             "ogc/gml/operation_method"
+    autoload :OperationMethodProperty,
+             "ogc/gml/operation_method_property"
+    autoload :OperationParameter,
+             "ogc/gml/operation_parameter"
+    autoload :OperationParameterGroup,
+             "ogc/gml/operation_parameter_group"
+    autoload :OperationParameterGroupProperty,
+             "ogc/gml/operation_parameter_group_property"
+    autoload :OperationParameterProperty,
+             "ogc/gml/operation_parameter_property"
+    autoload :OperationProperty,
+             "ogc/gml/operation_property"
+    autoload :OrientableCurve,
+             "ogc/gml/orientable_curve"
+    autoload :OrientableSurface,
+             "ogc/gml/orientable_surface"
+    autoload :ParameterValue,
+             "ogc/gml/parameter_value"
+    autoload :ParameterValueGroup,
+             "ogc/gml/parameter_value_group"
+    autoload :PassThroughOperation,
+             "ogc/gml/pass_through_operation"
+    autoload :PassThroughOperationProperty,
+             "ogc/gml/pass_through_operation_property"
+    autoload :Point,
+             "ogc/gml/point"
+    autoload :PointArrayProperty,
+             "ogc/gml/point_array_property"
+    autoload :PointProperty,
+             "ogc/gml/point_property"
+    autoload :PolarCS,
+             "ogc/gml/polar_cs"
+    autoload :PolarCSProperty,
+             "ogc/gml/polar_cs_property"
+    autoload :Polygon,
+             "ogc/gml/polygon"
+    autoload :PolygonPatch,
+             "ogc/gml/polygon_patch"
+    autoload :PrimeMeridian,
+             "ogc/gml/prime_meridian"
+    autoload :PrimeMeridianProperty,
+             "ogc/gml/prime_meridian_property"
+    autoload :PriorityLocationProperty,
+             "ogc/gml/priority_location_property"
+    autoload :ProcedureProperty,
+             "ogc/gml/procedure_property"
+    autoload :ProjectedCRS,
+             "ogc/gml/projected_crs"
+    autoload :ProjectedCRSProperty,
+             "ogc/gml/projected_crs_property"
+    autoload :Quantity,
+             "ogc/gml/quantity"
+    autoload :QuantityExtent,
+             "ogc/gml/quantity_extent"
+    autoload :RangeSet,
+             "ogc/gml/range_set"
+    autoload :Rectangle,
+             "ogc/gml/rectangle"
+    autoload :RectifiedGrid,
+             "ogc/gml/rectified_grid"
+    autoload :RefLocation,
+             "ogc/gml/ref_location"
+    autoload :Reference,
+             "ogc/gml/reference"
+    autoload :RelatedTime,
+             "ogc/gml/related_time"
+    autoload :RemoteSchema,
+             "ogc/gml/reference"
+    autoload :Result,
+             "ogc/gml/result"
+    autoload :Ring,
+             "ogc/gml/ring"
+    autoload :SecondDefiningParameter1,
+             "ogc/gml/second_defining_parameter1"
+    autoload :SecondDefiningParameter2,
+             "ogc/gml/second_defining_parameter2"
+    autoload :SequenceRule,
+             "ogc/gml/sequence_rule"
+    autoload :Shell,
+             "ogc/gml/shell"
+    autoload :ShellProperty,
+             "ogc/gml/shell_property"
+    autoload :SingleCRSProperty,
+             "ogc/gml/single_crs_property"
+    autoload :SingleOperationProperty,
+             "ogc/gml/single_operation_property"
+    autoload :Solid,
+             "ogc/gml/solid"
+    autoload :SolidArrayProperty,
+             "ogc/gml/solid_array_property"
+    autoload :SolidProperty,
+             "ogc/gml/solid_property"
+    autoload :Sphere,
+             "ogc/gml/sphere"
+    autoload :SphericalCS,
+             "ogc/gml/spherical_cs"
+    autoload :SphericalCSProperty,
+             "ogc/gml/spherical_cs_property"
+    autoload :StringOrRef,
+             "ogc/gml/string_or_ref"
+    autoload :Surface,
+             "ogc/gml/surface"
+    autoload :SurfaceArrayProperty,
+             "ogc/gml/surface_array_property"
+    autoload :SurfacePatchArrayProperty,
+             "ogc/gml/surface_patch_array_property"
+    autoload :SurfaceProperty,
+             "ogc/gml/surface_property"
+    autoload :TargetProperty,
+             "ogc/gml/target_property"
+    autoload :TemporalCRS,
+             "ogc/gml/temporal_crs"
+    autoload :TemporalCRSProperty,
+             "ogc/gml/temporal_crs_property"
+    autoload :TemporalCS,
+             "ogc/gml/temporal_cs"
+    autoload :TemporalCSProperty,
+             "ogc/gml/temporal_cs_property"
+    autoload :TemporalDatum,
+             "ogc/gml/temporal_datum"
+    autoload :TemporalDatumProperty,
+             "ogc/gml/temporal_datum_property"
+    autoload :TimeCS,
+             "ogc/gml/time_cs"
+    autoload :TimeCSProperty,
+             "ogc/gml/time_cs_property"
+    autoload :TimeCalendar,
+             "ogc/gml/time_calendar"
+    autoload :TimeCalendarEra,
+             "ogc/gml/time_calendar_era"
+    autoload :TimeCalendarEraProperty,
+             "ogc/gml/time_calendar_era_property"
+    autoload :TimeCalendarProperty,
+             "ogc/gml/time_calendar_property"
+    autoload :TimeClock,
+             "ogc/gml/time_clock"
+    autoload :TimeCoordinateSystem,
+             "ogc/gml/time_coordinate_system"
+    autoload :TimeEdge,
+             "ogc/gml/time_edge"
+    autoload :TimeEdgeProperty,
+             "ogc/gml/time_edge_property"
+    autoload :TimeInstant,
+             "ogc/gml/time_instant"
+    autoload :TimeInstantProperty,
+             "ogc/gml/time_instant_property"
+    autoload :TimeIntervalLength,
+             "ogc/gml/time_interval_length"
+    autoload :TimeNode,
+             "ogc/gml/time_node"
+    autoload :TimeNodeProperty,
+             "ogc/gml/time_node_property"
+    autoload :TimeOrdinalEra,
+             "ogc/gml/time_ordinal_era"
+    autoload :TimeOrdinalEraProperty,
+             "ogc/gml/time_ordinal_era_property"
+    autoload :TimeOrdinalReferenceSystem,
+             "ogc/gml/time_ordinal_reference_system"
+    autoload :TimePeriod,
+             "ogc/gml/time_period"
+    autoload :TimePeriodProperty,
+             "ogc/gml/time_period_property"
+    autoload :TimePosition,
+             "ogc/gml/time_position"
+    autoload :TimePrimitiveProperty,
+             "ogc/gml/time_primitive_property"
+    autoload :TimeReferenceSystem,
+             "ogc/gml/time_reference_system"
+    autoload :TimeTopologyComplex,
+             "ogc/gml/time_topology_complex"
+    autoload :TimeTopologyPrimitiveProperty,
+             "ogc/gml/time_topology_primitive_property"
+    autoload :Tin,
+             "ogc/gml/tin"
+    autoload :TopoComplex,
+             "ogc/gml/topo_complex"
+    autoload :TopoComplexProperty,
+             "ogc/gml/topo_complex_property"
+    autoload :TopoCurve,
+             "ogc/gml/topo_curve"
+    autoload :TopoCurveProperty,
+             "ogc/gml/topo_curve_property"
+    autoload :TopoPoint,
+             "ogc/gml/topo_point"
+    autoload :TopoPointProperty,
+             "ogc/gml/topo_point_property"
+    autoload :TopoPrimitiveArrayAssociation,
+             "ogc/gml/topo_primitive_array_association"
+    autoload :TopoPrimitiveMember,
+             "ogc/gml/topo_primitive_member"
+    autoload :TopoSolid,
+             "ogc/gml/topo_solid"
+    autoload :TopoSolidProperty,
+             "ogc/gml/topo_solid_property"
+    autoload :TopoSurface,
+             "ogc/gml/topo_surface"
+    autoload :TopoSurfaceProperty,
+             "ogc/gml/topo_surface_property"
+    autoload :TopoVolume,
+             "ogc/gml/topo_volume"
+    autoload :TopoVolumeProperty,
+             "ogc/gml/topo_volume_property"
+    autoload :Transformation,
+             "ogc/gml/transformation"
+    autoload :TransformationProperty,
+             "ogc/gml/transformation_property"
+    autoload :Triangle,
+             "ogc/gml/triangle"
+    autoload :UnitDefinition,
+             "ogc/gml/unit_definition"
+    autoload :UnitOfMeasure,
+             "ogc/gml/unit_of_measure"
+    autoload :UserDefinedCS,
+             "ogc/gml/user_defined_cs"
+    autoload :UserDefinedCSProperty,
+             "ogc/gml/user_defined_cs_property"
+    autoload :VERSION,
+             "ogc/gml/version"
+    autoload :ValueArray,
+             "ogc/gml/value_array"
+    autoload :ValueArrayProperty,
+             "ogc/gml/value_array_property"
+    autoload :ValueProperty,
+             "ogc/gml/value_property"
+    autoload :Vector,
+             "ogc/gml/vector"
+    autoload :VerticalCRS,
+             "ogc/gml/vertical_crs"
+    autoload :VerticalCRSProperty,
+             "ogc/gml/vertical_crs_property"
+    autoload :VerticalCS,
+             "ogc/gml/vertical_cs"
+    autoload :VerticalCSProperty,
+             "ogc/gml/vertical_cs_property"
+    autoload :VerticalDatum,
+             "ogc/gml/vertical_datum"
+    autoload :VerticalDatumProperty,
+             "ogc/gml/vertical_datum_property"
   end
 end
-
-require_relative "gml/namespace"
-require_relative "gml/abstract_continuous_coverage"
-require_relative "gml/abstract_coordinate_operation"
-require_relative "gml/abstract_coordinate_system"
-require_relative "gml/abstract_coverage"
-require_relative "gml/abstract_crs"
-require_relative "gml/abstract_curve_segment"
-require_relative "gml/abstract_curve"
-require_relative "gml/abstract_datum"
-require_relative "gml/abstract_feature_collection"
-require_relative "gml/abstract_feature"
-require_relative "gml/abstract_general_conversion"
-require_relative "gml/abstract_general_derived_crs"
-require_relative "gml/abstract_general_operation_parameter_property"
-require_relative "gml/abstract_general_operation_parameter"
-require_relative "gml/abstract_general_parameter_value_property"
-require_relative "gml/abstract_general_parameter_value"
-require_relative "gml/abstract_general_transformation"
-require_relative "gml/abstract_geometric_aggregate"
-require_relative "gml/abstract_geometric_primitive"
-require_relative "gml/abstract_geometry"
-require_relative "gml/abstract_gml"
-require_relative "gml/abstract_gridded_surface"
-require_relative "gml/abstract_meta_data"
-require_relative "gml/abstract_parametric_curve_surface"
-require_relative "gml/abstract_ring_property"
-require_relative "gml/abstract_ring"
-require_relative "gml/abstract_solid"
-require_relative "gml/abstract_surface_patch"
-require_relative "gml/abstract_surface"
-require_relative "gml/abstract_time_complex"
-require_relative "gml/abstract_time_geometric_primitive"
-require_relative "gml/abstract_time_object"
-require_relative "gml/abstract_time_primitive"
-require_relative "gml/abstract_time_slice"
-require_relative "gml/abstract_time_topology_primitive"
-require_relative "gml/abstract_topo_primitive"
-require_relative "gml/abstract_topology"
-require_relative "gml/affine_cs_property"
-require_relative "gml/affine_cs"
-require_relative "gml/affine_placement"
-require_relative "gml/angle"
-require_relative "gml/arc_by_bulge"
-require_relative "gml/arc_by_center_point"
-require_relative "gml/arc_string_by_bulge"
-require_relative "gml/arc_string"
-require_relative "gml/arc"
-require_relative "gml/array_association"
-require_relative "gml/array"
-require_relative "gml/association_role"
-require_relative "gml/b_spline"
-require_relative "gml/bag"
-require_relative "gml/base_unit"
-require_relative "gml/bezier"
-require_relative "gml/boolean"
-require_relative "gml/bounding_shape"
-require_relative "gml/cartesian_cs_property"
-require_relative "gml/cartesian_cs"
-require_relative "gml/category"
-require_relative "gml/category_extent"
-require_relative "gml/circle_by_center_point"
-require_relative "gml/circle"
-require_relative "gml/clothoid"
-require_relative "gml/code_or_nil_reason_list"
-require_relative "gml/code"
-require_relative "gml/code_with_authority"
-require_relative "gml/composite_curve"
-require_relative "gml/composite_solid"
-require_relative "gml/composite_surface"
-require_relative "gml/composite_value"
-require_relative "gml/compound_crs_property"
-require_relative "gml/compound_crs"
-require_relative "gml/concatenated_operation_property"
-require_relative "gml/concatenated_operation"
-require_relative "gml/cone"
-require_relative "gml/control_point"
-require_relative "gml/conventional_unit"
-require_relative "gml/conversion_property"
-require_relative "gml/conversion_to_preferred_unit"
-require_relative "gml/conversion"
-require_relative "gml/coordinate_operation_accuracy"
-require_relative "gml/coordinate_operation_property"
-require_relative "gml/coordinate_system_axis_property"
-require_relative "gml/coordinate_system_axis"
-require_relative "gml/coordinate_system_property"
-require_relative "gml/coordinates"
-require_relative "gml/count"
-require_relative "gml/coverage_function"
-require_relative "gml/crs_property"
-require_relative "gml/cubic_spline"
-require_relative "gml/curve_array_property"
-require_relative "gml/curve_property"
-require_relative "gml/curve_segment_array_property"
-require_relative "gml/curve"
-require_relative "gml/cylinder"
-require_relative "gml/cylindrical_cs_property"
-require_relative "gml/cylindrical_cs"
-require_relative "gml/data_block"
-require_relative "gml/datum_property"
-require_relative "gml/definition_proxy"
-require_relative "gml/definition"
-require_relative "gml/degrees"
-require_relative "gml/derivation_unit_term"
-require_relative "gml/derived_crs_property"
-require_relative "gml/derived_crs"
-require_relative "gml/derived_unit"
-require_relative "gml/dictionary_entry"
-require_relative "gml/dictionary"
-require_relative "gml/direct_position_list"
-require_relative "gml/direct_position"
-require_relative "gml/directed_edge_property"
-require_relative "gml/directed_face_property"
-require_relative "gml/directed_node_property"
-require_relative "gml/directed_observation_at_distance"
-require_relative "gml/directed_observation"
-require_relative "gml/directed_topo_solid_property"
-require_relative "gml/direction_description"
-require_relative "gml/direction_property"
-require_relative "gml/direction_vector"
-require_relative "gml/discrete_coverage"
-require_relative "gml/dms_angle"
-require_relative "gml/domain_of_validity"
-require_relative "gml/domain_set"
-require_relative "gml/dynamic_feature_collection"
-require_relative "gml/dynamic_feature_member"
-require_relative "gml/dynamic_feature"
-require_relative "gml/edge"
-require_relative "gml/ellipsoid_property"
-require_relative "gml/ellipsoid"
-require_relative "gml/ellipsoidal_cs_property"
-require_relative "gml/ellipsoidal_cs"
-require_relative "gml/engineering_crs_property"
-require_relative "gml/engineering_crs"
-require_relative "gml/engineering_datum_property"
-require_relative "gml/engineering_datum"
-require_relative "gml/envelope"
-require_relative "gml/envelope_with_time_period"
-require_relative "gml/face_or_topo_solid_property"
-require_relative "gml/face"
-require_relative "gml/feature_array_property"
-require_relative "gml/feature_collection"
-require_relative "gml/feature_property"
-require_relative "gml/file"
-require_relative "gml/formula_citation"
-require_relative "gml/formula"
-require_relative "gml/general_conversion_property"
-require_relative "gml/general_transformation_property"
-require_relative "gml/generic_meta_data"
-require_relative "gml/geocentric_crs_property"
-require_relative "gml/geocentric_crs"
-require_relative "gml/geodesic_string"
-require_relative "gml/geodesic"
-require_relative "gml/geodetic_crs_property"
-require_relative "gml/geodetic_crs"
-require_relative "gml/geodetic_datum_property"
-require_relative "gml/geodetic_datum"
-require_relative "gml/geographic_crs_property"
-require_relative "gml/geographic_crs"
-require_relative "gml/geometric_complex"
-require_relative "gml/geometric_primitive_property"
-require_relative "gml/geometry_array_property"
-require_relative "gml/geometry_property"
-require_relative "gml/grid_envelope"
-require_relative "gml/grid_function"
-require_relative "gml/grid_limits"
-require_relative "gml/grid"
-require_relative "gml/history_property"
-require_relative "gml/image_crs_property"
-require_relative "gml/image_crs"
-require_relative "gml/image_datum_property"
-require_relative "gml/image_datum"
-require_relative "gml/indirect_entry"
-require_relative "gml/inline_property"
-require_relative "gml/knot_property"
-require_relative "gml/knot"
-require_relative "gml/length"
-require_relative "gml/line_string_segment_array_property"
-require_relative "gml/line_string_segment"
-require_relative "gml/line_string"
-require_relative "gml/linear_cs_property"
-require_relative "gml/linear_cs"
-require_relative "gml/linear_ring"
-require_relative "gml/location_property"
-require_relative "gml/mapping_rule"
-require_relative "gml/measure_list"
-require_relative "gml/measure_or_nil_reason_list"
-require_relative "gml/measure"
-require_relative "gml/meta_data_property"
-require_relative "gml/moving_object_status"
-require_relative "gml/multi_curve_property"
-require_relative "gml/multi_curve"
-require_relative "gml/multi_geometry_property"
-require_relative "gml/multi_geometry"
-require_relative "gml/multi_point_property"
-require_relative "gml/multi_point"
-require_relative "gml/multi_solid_property"
-require_relative "gml/multi_solid"
-require_relative "gml/multi_surface_property"
-require_relative "gml/multi_surface"
-require_relative "gml/node_or_edge_property"
-require_relative "gml/node_property"
-require_relative "gml/node"
-require_relative "gml/oblique_cartesian_cs_property"
-require_relative "gml/oblique_cartesian_cs"
-require_relative "gml/observation"
-require_relative "gml/offset_curve"
-require_relative "gml/operation_method_property"
-require_relative "gml/operation_method"
-require_relative "gml/operation_parameter_group_property"
-require_relative "gml/operation_parameter_group"
-require_relative "gml/operation_parameter_property"
-require_relative "gml/operation_parameter"
-require_relative "gml/operation_property"
-require_relative "gml/orientable_curve"
-require_relative "gml/orientable_surface"
-require_relative "gml/parameter_value_group"
-require_relative "gml/parameter_value"
-require_relative "gml/pass_through_operation_property"
-require_relative "gml/pass_through_operation"
-require_relative "gml/point_array_property"
-require_relative "gml/point_property"
-require_relative "gml/point"
-require_relative "gml/polar_cs_property"
-require_relative "gml/polar_cs"
-require_relative "gml/polygon_patch"
-require_relative "gml/polygon"
-require_relative "gml/prime_meridian_property"
-require_relative "gml/prime_meridian"
-require_relative "gml/priority_location_property"
-require_relative "gml/procedure_property"
-require_relative "gml/projected_crs_property"
-require_relative "gml/projected_crs"
-require_relative "gml/quantity"
-require_relative "gml/quantity_extent"
-require_relative "gml/range_set"
-require_relative "gml/rectangle"
-require_relative "gml/rectified_grid"
-require_relative "gml/ref_location"
-require_relative "gml/reference"
-require_relative "gml/related_time"
-require_relative "gml/result"
-require_relative "gml/ring"
-require_relative "gml/second_defining_parameter1"
-require_relative "gml/second_defining_parameter2"
-require_relative "gml/sequence_rule"
-require_relative "gml/shell_property"
-require_relative "gml/shell"
-require_relative "gml/single_crs_property"
-require_relative "gml/single_operation_property"
-require_relative "gml/solid_array_property"
-require_relative "gml/solid_property"
-require_relative "gml/solid"
-require_relative "gml/sphere"
-require_relative "gml/spherical_cs_property"
-require_relative "gml/spherical_cs"
-require_relative "gml/string_or_ref"
-require_relative "gml/surface_array_property"
-require_relative "gml/surface_patch_array_property"
-require_relative "gml/surface_property"
-require_relative "gml/surface"
-require_relative "gml/target_property"
-require_relative "gml/temporal_crs_property"
-require_relative "gml/temporal_crs"
-require_relative "gml/temporal_cs_property"
-require_relative "gml/temporal_cs"
-require_relative "gml/temporal_datum_property"
-require_relative "gml/temporal_datum"
-require_relative "gml/time_calendar_era_property"
-require_relative "gml/time_calendar_era"
-require_relative "gml/time_calendar_property"
-require_relative "gml/time_calendar"
-require_relative "gml/time_clock"
-require_relative "gml/time_coordinate_system"
-require_relative "gml/time_cs_property"
-require_relative "gml/time_cs"
-require_relative "gml/time_edge_property"
-require_relative "gml/time_edge"
-require_relative "gml/time_instant_property"
-require_relative "gml/time_instant"
-require_relative "gml/time_interval_length"
-require_relative "gml/time_node_property"
-require_relative "gml/time_node"
-require_relative "gml/time_ordinal_era_property"
-require_relative "gml/time_ordinal_era"
-require_relative "gml/time_ordinal_reference_system"
-require_relative "gml/time_period_property"
-require_relative "gml/time_period"
-require_relative "gml/time_position"
-require_relative "gml/time_primitive_property"
-require_relative "gml/time_reference_system"
-require_relative "gml/time_topology_complex"
-require_relative "gml/time_topology_primitive_property"
-require_relative "gml/tin"
-require_relative "gml/topo_complex_property"
-require_relative "gml/topo_complex"
-require_relative "gml/topo_curve_property"
-require_relative "gml/topo_curve"
-require_relative "gml/topo_point_property"
-require_relative "gml/topo_point"
-require_relative "gml/topo_primitive_array_association"
-require_relative "gml/topo_primitive_member"
-require_relative "gml/topo_solid_property"
-require_relative "gml/topo_solid"
-require_relative "gml/topo_surface_property"
-require_relative "gml/topo_surface"
-require_relative "gml/topo_volume_property"
-require_relative "gml/topo_volume"
-require_relative "gml/transformation_property"
-require_relative "gml/transformation"
-require_relative "gml/triangle"
-require_relative "gml/unit_definition"
-require_relative "gml/unit_of_measure"
-require_relative "gml/user_defined_cs_property"
-require_relative "gml/user_defined_cs"
-require_relative "gml/value_array_property"
-require_relative "gml/value_array"
-require_relative "gml/value_property"
-require_relative "gml/vector"
-require_relative "gml/vertical_crs_property"
-require_relative "gml/vertical_crs"
-require_relative "gml/vertical_cs_property"
-require_relative "gml/vertical_cs"
-require_relative "gml/vertical_datum_property"
-require_relative "gml/vertical_datum"

--- a/lib/ogc/gml/abstract_continuous_coverage.rb
+++ b/lib/ogc/gml/abstract_continuous_coverage.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "coverage_function"
-require_relative "abstract_coverage"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_coordinate_operation.rb
+++ b/lib/ogc/gml/abstract_coordinate_operation.rb
@@ -2,10 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinate_operation_accuracy"
-require_relative "crs_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractCoordinateOperation < AbstractTopology

--- a/lib/ogc/gml/abstract_coordinate_system.rb
+++ b/lib/ogc/gml/abstract_coordinate_system.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "coordinate_system_axis_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class AbstractCoordinateSystem < Lutaml::Model::Serializable

--- a/lib/ogc/gml/abstract_coverage.rb
+++ b/lib/ogc/gml/abstract_coverage.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "bounding_shape"
-require_relative "domain_set"
-require_relative "location_property"
-require_relative "range_set"
-require_relative "abstract_topology"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_crs.rb
+++ b/lib/ogc/gml/abstract_crs.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractCRS < AbstractTopology

--- a/lib/ogc/gml/abstract_curve.rb
+++ b/lib/ogc/gml/abstract_curve.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_geometric_primitive"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_datum.rb
+++ b/lib/ogc/gml/abstract_datum.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractDatum < AbstractTopology

--- a/lib/ogc/gml/abstract_feature.rb
+++ b/lib/ogc/gml/abstract_feature.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "bounding_shape"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "location_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractFeature < AbstractTopology

--- a/lib/ogc/gml/abstract_feature_collection.rb
+++ b/lib/ogc/gml/abstract_feature_collection.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "bounding_shape"
-require_relative "feature_array_property"
-require_relative "feature_property"
-require_relative "location_property"
-require_relative "abstract_topology"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_general_conversion.rb
+++ b/lib/ogc/gml/abstract_general_conversion.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "coordinate_operation_accuracy"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractGeneralConversion < AbstractTopology

--- a/lib/ogc/gml/abstract_general_derived_crs.rb
+++ b/lib/ogc/gml/abstract_general_derived_crs.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "general_conversion_property"
-require_relative "abstract_crs"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_general_operation_parameter.rb
+++ b/lib/ogc/gml/abstract_general_operation_parameter.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_topology"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_general_operation_parameter_property.rb
+++ b/lib/ogc/gml/abstract_general_operation_parameter_property.rb
@@ -2,16 +2,8 @@
 
 require "lutaml/model"
 
-require_relative "abstract_general_operation_parameter"
-
 module Ogc
   module Gml
-    class RemoteSchema < Lutaml::Model::Type::String
-      xml do
-        namespace Namespace
-      end
-    end
-
     class AbstractGeneralOperationParameterProperty < Lutaml::Model::Serializable
       attribute :nil_reason, :string
       attribute :remote_schema, RemoteSchema

--- a/lib/ogc/gml/abstract_general_parameter_value_property.rb
+++ b/lib/ogc/gml/abstract_general_parameter_value_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_general_parameter_value"
-
 module Ogc
   module Gml
     class AbstractGeneralParameterValueProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/abstract_general_transformation.rb
+++ b/lib/ogc/gml/abstract_general_transformation.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_operation"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_geometric_aggregate.rb
+++ b/lib/ogc/gml/abstract_geometric_aggregate.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_geometric_primitive"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_geometric_primitive.rb
+++ b/lib/ogc/gml/abstract_geometric_primitive.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class AbstractGeometricPrimitive < Lutaml::Model::Serializable

--- a/lib/ogc/gml/abstract_geometry.rb
+++ b/lib/ogc/gml/abstract_geometry.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_geometric_primitive"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_gml.rb
+++ b/lib/ogc/gml/abstract_gml.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractGML < AbstractTopology

--- a/lib/ogc/gml/abstract_meta_data.rb
+++ b/lib/ogc/gml/abstract_meta_data.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "identifier"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_ring_property.rb
+++ b/lib/ogc/gml/abstract_ring_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_ring"
-
 module Ogc
   module Gml
     class AbstractRingProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/abstract_solid.rb
+++ b/lib/ogc/gml/abstract_solid.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_geometric_primitive"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_surface.rb
+++ b/lib/ogc/gml/abstract_surface.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_geometric_primitive"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/abstract_time_complex.rb
+++ b/lib/ogc/gml/abstract_time_complex.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractTimeComplex < AbstractTopology

--- a/lib/ogc/gml/abstract_time_geometric_primitive.rb
+++ b/lib/ogc/gml/abstract_time_geometric_primitive.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "related_time"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class AbstractTimeGeometricPrimitive < Lutaml::Model::Serializable

--- a/lib/ogc/gml/abstract_time_object.rb
+++ b/lib/ogc/gml/abstract_time_object.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractTimeObject < AbstractTopology

--- a/lib/ogc/gml/abstract_time_primitive.rb
+++ b/lib/ogc/gml/abstract_time_primitive.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-# require_relative "related_time"
 
 module Ogc
   module Gml
-    class RelatedTime < Lutaml::Model::Serializable
-    end
-
     class AbstractTimePrimitive < AbstractTopology
       attribute :related_time, RelatedTime, collection: true
 

--- a/lib/ogc/gml/abstract_time_slice.rb
+++ b/lib/ogc/gml/abstract_time_slice.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "time_primitive_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractTimeSlice < AbstractTopology

--- a/lib/ogc/gml/abstract_time_topology_primitive.rb
+++ b/lib/ogc/gml/abstract_time_topology_primitive.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "related_time"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractTimeTopologyPrimitive < AbstractTopology

--- a/lib/ogc/gml/abstract_topo_primitive.rb
+++ b/lib/ogc/gml/abstract_topo_primitive.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class AbstractTopoPrimitive < AbstractTopology

--- a/lib/ogc/gml/abstract_topology.rb
+++ b/lib/ogc/gml/abstract_topology.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/affine_cs.rb
+++ b/lib/ogc/gml/affine_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/affine_cs_property.rb
+++ b/lib/ogc/gml/affine_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "affine_cs"
-
 module Ogc
   module Gml
     class AffineCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/affine_placement.rb
+++ b/lib/ogc/gml/affine_placement.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "direct_position"
-require_relative "vector"
-
 module Ogc
   module Gml
     class AffinePlacement < Lutaml::Model::Serializable

--- a/lib/ogc/gml/angle.rb
+++ b/lib/ogc/gml/angle.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "measure"
-require_relative "unit_of_measure"
-
 module Ogc
   module Gml
     class Angle < UnitOfMeasure

--- a/lib/ogc/gml/arc.rb
+++ b/lib/ogc/gml/arc.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "arc_string"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/arc_by_bulge.rb
+++ b/lib/ogc/gml/arc_by_bulge.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "vector"
-require_relative "arc"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/arc_by_center_point.rb
+++ b/lib/ogc/gml/arc_by_center_point.rb
@@ -2,11 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "angle"
-require_relative "direct_position"
-require_relative "length"
-require_relative "arc"
-
 module Ogc
   module Gml
     class ArcByCenterPoint < Arc

--- a/lib/ogc/gml/arc_string.rb
+++ b/lib/ogc/gml/arc_string.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinates"
-require_relative "direct_position_list"
-require_relative "direct_position"
-require_relative "point_property"
-require_relative "abstract_curve_segment"
-
 module Ogc
   module Gml
     class ArcString < AbstractCurveSegment

--- a/lib/ogc/gml/arc_string_by_bulge.rb
+++ b/lib/ogc/gml/arc_string_by_bulge.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "vector"
-require_relative "arc_string"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/array.rb
+++ b/lib/ogc/gml/array.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "array_association"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class Array < AbstractTopology

--- a/lib/ogc/gml/b_spline.rb
+++ b/lib/ogc/gml/b_spline.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "bezier"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/bag.rb
+++ b/lib/ogc/gml/bag.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "array_association"
-require_relative "association_role"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class Bag < AbstractTopology

--- a/lib/ogc/gml/base_unit.rb
+++ b/lib/ogc/gml/base_unit.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class BaseUnit < AbstractTopology

--- a/lib/ogc/gml/bezier.rb
+++ b/lib/ogc/gml/bezier.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinates"
-require_relative "direct_position_list"
-require_relative "knot_property"
-require_relative "point_property"
-require_relative "abstract_curve_segment"
-
 module Ogc
   module Gml
     class Bezier < AbstractCurveSegment

--- a/lib/ogc/gml/bounding_shape.rb
+++ b/lib/ogc/gml/bounding_shape.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "envelope"
-
 module Ogc
   module Gml
     class BoundingShape < Lutaml::Model::Serializable

--- a/lib/ogc/gml/cartesian_cs.rb
+++ b/lib/ogc/gml/cartesian_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/cartesian_cs_property.rb
+++ b/lib/ogc/gml/cartesian_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "cartesian_cs"
-
 module Ogc
   module Gml
     class CartesianCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/category.rb
+++ b/lib/ogc/gml/category.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-
 module Ogc
   module Gml
     class Category < Lutaml::Model::Serializable

--- a/lib/ogc/gml/category_extent.rb
+++ b/lib/ogc/gml/category_extent.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code_or_nil_reason_list"
-
 module Ogc
   module Gml
     class CategoryExtent < Lutaml::Model::Serializable

--- a/lib/ogc/gml/circle.rb
+++ b/lib/ogc/gml/circle.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "arc_string"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/circle_by_center_point.rb
+++ b/lib/ogc/gml/circle_by_center_point.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinates"
-require_relative "direct_position_list"
-require_relative "direct_position"
-require_relative "length"
-require_relative "point_property"
-require_relative "abstract_curve_segment"
-
 module Ogc
   module Gml
     class CircleByCenterPoint < AbstractCurveSegment

--- a/lib/ogc/gml/clothoid.rb
+++ b/lib/ogc/gml/clothoid.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "ref_location"
-require_relative "abstract_curve_segment"
-
 module Ogc
   module Gml
     class Clothoid < AbstractCurveSegment

--- a/lib/ogc/gml/code_with_authority.rb
+++ b/lib/ogc/gml/code_with_authority.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-
 module Ogc
   module Gml
     class CodeWithAuthority < Lutaml::Model::Serializable

--- a/lib/ogc/gml/composite_curve.rb
+++ b/lib/ogc/gml/composite_curve.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "curve_property"
-require_relative "abstract_geometric_aggregate"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/composite_solid.rb
+++ b/lib/ogc/gml/composite_solid.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "solid_property"
-require_relative "abstract_geometric_aggregate"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/composite_surface.rb
+++ b/lib/ogc/gml/composite_surface.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "surface_property"
-require_relative "abstract_geometric_aggregate"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/composite_value.rb
+++ b/lib/ogc/gml/composite_value.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "value_array_property"
-require_relative "value_property"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class CompositeValue < Lutaml::Model::Serializable

--- a/lib/ogc/gml/compound_crs.rb
+++ b/lib/ogc/gml/compound_crs.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "single_crs_property"
-require_relative "abstract_crs"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/compound_crs_property.rb
+++ b/lib/ogc/gml/compound_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "compound_crs"
-
 module Ogc
   module Gml
     class CompoundCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/concatenated_operation.rb
+++ b/lib/ogc/gml/concatenated_operation.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "coordinate_operation_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_coordinate_operation"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class ConcatenatedOperation < AbstractCoordinateOperation

--- a/lib/ogc/gml/concatenated_operation_property.rb
+++ b/lib/ogc/gml/concatenated_operation_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "concatenated_operation"
-
 module Ogc
   module Gml
     class ConcatenatedOperationProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/cone.rb
+++ b/lib/ogc/gml/cone.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "cylinder"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/control_point.rb
+++ b/lib/ogc/gml/control_point.rb
@@ -2,10 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "direct_position_list"
-require_relative "direct_position"
-require_relative "point_property"
-
 module Ogc
   module Gml
     class ControlPoint < Lutaml::Model::Serializable

--- a/lib/ogc/gml/conventional_unit.rb
+++ b/lib/ogc/gml/conventional_unit.rb
@@ -2,15 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "conversion_to_preferred_unit"
-require_relative "derivation_unit_term"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class ConventionalUnit < AbstractTopology

--- a/lib/ogc/gml/conversion.rb
+++ b/lib/ogc/gml/conversion.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_general_parameter_value_property"
-require_relative "operation_method_property"
-require_relative "abstract_general_conversion"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/conversion_property.rb
+++ b/lib/ogc/gml/conversion_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "conversion"
-
 module Ogc
   module Gml
     class ConversionProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/conversion_to_preferred_unit.rb
+++ b/lib/ogc/gml/conversion_to_preferred_unit.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "formula"
-
 module Ogc
   module Gml
     class ConversionToPreferredUnit < Lutaml::Model::Serializable

--- a/lib/ogc/gml/coordinate_operation_accuracy.rb
+++ b/lib/ogc/gml/coordinate_operation_accuracy.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "string_or_ref"
-
 module Ogc
   module Gml
     class CoordinateOperationAccuracy < Lutaml::Model::Serializable

--- a/lib/ogc/gml/coordinate_operation_property.rb
+++ b/lib/ogc/gml/coordinate_operation_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_coordinate_operation"
-
 module Ogc
   module Gml
     class CoordinateOperationProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/coordinate_system_axis.rb
+++ b/lib/ogc/gml/coordinate_system_axis.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class CoordinateSystemAxis < Lutaml::Model::Serializable

--- a/lib/ogc/gml/coordinate_system_axis_property.rb
+++ b/lib/ogc/gml/coordinate_system_axis_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinate_system_axis"
-
 module Ogc
   module Gml
     class CoordinateSystemAxisProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/coordinate_system_property.rb
+++ b/lib/ogc/gml/coordinate_system_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_coordinate_system"
-
 module Ogc
   module Gml
     class CoordinateSystemProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/coverage_function.rb
+++ b/lib/ogc/gml/coverage_function.rb
@@ -2,10 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "grid_function"
-require_relative "mapping_rule"
-require_relative "string_or_ref"
-
 module Ogc
   module Gml
     class CoverageFunction < Lutaml::Model::Serializable

--- a/lib/ogc/gml/crs_property.rb
+++ b/lib/ogc/gml/crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_crs"
-
 module Ogc
   module Gml
     class CRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/cubic_spline.rb
+++ b/lib/ogc/gml/cubic_spline.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinates"
-require_relative "direct_position_list"
-require_relative "direct_position"
-require_relative "point_property"
-require_relative "vector"
-require_relative "abstract_curve_segment"
-
 module Ogc
   module Gml
     class CubicSpline < AbstractCurveSegment

--- a/lib/ogc/gml/curve.rb
+++ b/lib/ogc/gml/curve.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "curve_segment_array_property"
-require_relative "abstract_curve"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/curve_array_property.rb
+++ b/lib/ogc/gml/curve_array_property.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_curve"
-require_relative "line_string"
-
 module Ogc
   module Gml
     class CurveArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/curve_property.rb
+++ b/lib/ogc/gml/curve_property.rb
@@ -2,11 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_curve"
-require_relative "curve"
-require_relative "orientable_curve"
-require_relative "line_string"
-
 module Ogc
   module Gml
     class CurveProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/curve_segment_array_property.rb
+++ b/lib/ogc/gml/curve_segment_array_property.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_curve_segment"
-require_relative "arc"
-require_relative "arc_by_center_point"
-require_relative "line_string_segment"
-require_relative "geodesic_string"
-
 module Ogc
   module Gml
     class CurveSegmentArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/cylinder.rb
+++ b/lib/ogc/gml/cylinder.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_gridded_surface"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/cylindrical_cs.rb
+++ b/lib/ogc/gml/cylindrical_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/cylindrical_cs_property.rb
+++ b/lib/ogc/gml/cylindrical_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "cylindrical_cs"
-
 module Ogc
   module Gml
     class CylindricalCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/data_block.rb
+++ b/lib/ogc/gml/data_block.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "association_role"
-require_relative "coordinates"
-
 module Ogc
   module Gml
     class DataBlock < Lutaml::Model::Serializable

--- a/lib/ogc/gml/datum_property.rb
+++ b/lib/ogc/gml/datum_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_datum"
-
 module Ogc
   module Gml
     class DatumProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/definition.rb
+++ b/lib/ogc/gml/definition.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class Definition < AbstractTopology

--- a/lib/ogc/gml/definition_proxy.rb
+++ b/lib/ogc/gml/definition_proxy.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class DefinitionProxy < AbstractTopology

--- a/lib/ogc/gml/derived_crs.rb
+++ b/lib/ogc/gml/derived_crs.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "code_with_authority"
-require_relative "coordinate_system_property"
-require_relative "single_crs_property"
-require_relative "abstract_general_derived_crs"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/derived_crs_property.rb
+++ b/lib/ogc/gml/derived_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "derived_crs"
-
 module Ogc
   module Gml
     class DerivedCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/derived_unit.rb
+++ b/lib/ogc/gml/derived_unit.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "derivation_unit_term"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class DerivedUnit < AbstractTopology

--- a/lib/ogc/gml/dictionary.rb
+++ b/lib/ogc/gml/dictionary.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code_with_authority"
-require_relative "dictionary_entry"
-require_relative "indirect_entry"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class AggregationType < Lutaml::Model::Type::String

--- a/lib/ogc/gml/dictionary_entry.rb
+++ b/lib/ogc/gml/dictionary_entry.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "definition"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class DictionaryEntry < Lutaml::Model::Serializable

--- a/lib/ogc/gml/directed_edge_property.rb
+++ b/lib/ogc/gml/directed_edge_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "edge"
-
 module Ogc
   module Gml
     class DirectedEdgeProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/directed_face_property.rb
+++ b/lib/ogc/gml/directed_face_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "face"
-
 module Ogc
   module Gml
     class DirectedFaceProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/directed_node_property.rb
+++ b/lib/ogc/gml/directed_node_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "node"
-
 module Ogc
   module Gml
     class DirectedNodeProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/directed_observation.rb
+++ b/lib/ogc/gml/directed_observation.rb
@@ -2,19 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "bounding_shape"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "direction_property"
-require_relative "location_property"
-require_relative "meta_data_property"
-require_relative "procedure_property"
-require_relative "reference"
-require_relative "result"
-require_relative "target_property"
-require_relative "time_primitive_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class DirectedObservation < AbstractTopology

--- a/lib/ogc/gml/directed_observation_at_distance.rb
+++ b/lib/ogc/gml/directed_observation_at_distance.rb
@@ -2,20 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "bounding_shape"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "direction_property"
-require_relative "location_property"
-require_relative "measure"
-require_relative "meta_data_property"
-require_relative "procedure_property"
-require_relative "reference"
-require_relative "result"
-require_relative "target_property"
-require_relative "time_primitive_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class DirectedObservationAtDistance < AbstractTopology

--- a/lib/ogc/gml/directed_topo_solid_property.rb
+++ b/lib/ogc/gml/directed_topo_solid_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "topo_solid"
-
 module Ogc
   module Gml
     class DirectedTopoSolidProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/direction_description.rb
+++ b/lib/ogc/gml/direction_description.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "reference"
-
 module Ogc
   module Gml
     class DirectionDescription < Lutaml::Model::Serializable

--- a/lib/ogc/gml/direction_property.rb
+++ b/lib/ogc/gml/direction_property.rb
@@ -2,11 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "direction_description"
-require_relative "direction_vector"
-require_relative "string_or_ref"
-
 module Ogc
   module Gml
     class DirectionProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/direction_vector.rb
+++ b/lib/ogc/gml/direction_vector.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "angle"
-require_relative "vector"
-
 module Ogc
   module Gml
     class DirectionVector < Lutaml::Model::Serializable

--- a/lib/ogc/gml/discrete_coverage.rb
+++ b/lib/ogc/gml/discrete_coverage.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_continuous_coverage"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/dms_angle.rb
+++ b/lib/ogc/gml/dms_angle.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "degrees"
-
 module Ogc
   module Gml
     class DMSAngle < Lutaml::Model::Serializable

--- a/lib/ogc/gml/domain_of_validity.rb
+++ b/lib/ogc/gml/domain_of_validity.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "string_or_ref"
-
 module Ogc
   module Gml
     class DomainOfValidity < Lutaml::Model::Serializable

--- a/lib/ogc/gml/domain_set.rb
+++ b/lib/ogc/gml/domain_set.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_geometry"
-require_relative "abstract_time_object"
-
 module Ogc
   module Gml
     class DomainSet < Lutaml::Model::Serializable

--- a/lib/ogc/gml/dynamic_feature.rb
+++ b/lib/ogc/gml/dynamic_feature.rb
@@ -2,17 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "bounding_shape"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "history_property"
-require_relative "location_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "time_primitive_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class DynamicFeature < AbstractTopology

--- a/lib/ogc/gml/dynamic_feature_collection.rb
+++ b/lib/ogc/gml/dynamic_feature_collection.rb
@@ -2,18 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "bounding_shape"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "dynamic_feature_member"
-require_relative "history_property"
-require_relative "location_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "time_primitive_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class DynamicFeatureCollection < AbstractTopology

--- a/lib/ogc/gml/dynamic_feature_member.rb
+++ b/lib/ogc/gml/dynamic_feature_member.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "dynamic_feature"
-
 module Ogc
   module Gml
     class DynamicFeatureMember < Lutaml::Model::Serializable

--- a/lib/ogc/gml/edge.rb
+++ b/lib/ogc/gml/edge.rb
@@ -2,16 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "curve_property"
-require_relative "directed_face_property"
-require_relative "directed_node_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "topo_solid_property"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class Edge < Lutaml::Model::Serializable

--- a/lib/ogc/gml/ellipsoid.rb
+++ b/lib/ogc/gml/ellipsoid.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "measure"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "second_defining_parameter1"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class Ellipsoid < AbstractTopology

--- a/lib/ogc/gml/ellipsoid_property.rb
+++ b/lib/ogc/gml/ellipsoid_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "ellipsoid"
-
 module Ogc
   module Gml
     class EllipsoidProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/ellipsoidal_cs.rb
+++ b/lib/ogc/gml/ellipsoidal_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/ellipsoidal_cs_property.rb
+++ b/lib/ogc/gml/ellipsoidal_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "ellipsoidal_cs"
-
 module Ogc
   module Gml
     class EllipsoidalCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/engineering_crs.rb
+++ b/lib/ogc/gml/engineering_crs.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "affine_cs_property"
-require_relative "cartesian_cs_property"
-require_relative "coordinate_system_property"
-require_relative "cylindrical_cs_property"
-require_relative "engineering_datum_property"
-require_relative "linear_cs_property"
-require_relative "polar_cs_property"
-require_relative "spherical_cs_property"
-require_relative "user_defined_cs_property"
-require_relative "abstract_crs"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/engineering_crs_property.rb
+++ b/lib/ogc/gml/engineering_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "engineering_crs"
-
 module Ogc
   module Gml
     class EngineeringCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/engineering_datum.rb
+++ b/lib/ogc/gml/engineering_datum.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_datum"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/engineering_datum_property.rb
+++ b/lib/ogc/gml/engineering_datum_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "engineering_datum"
-
 module Ogc
   module Gml
     class EngineeringDatumProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/envelope.rb
+++ b/lib/ogc/gml/envelope.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinates"
-require_relative "direct_position"
-
 module Ogc
   module Gml
     class Envelope < Lutaml::Model::Serializable

--- a/lib/ogc/gml/envelope_with_time_period.rb
+++ b/lib/ogc/gml/envelope_with_time_period.rb
@@ -2,10 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinates"
-require_relative "direct_position"
-require_relative "time_position"
-
 module Ogc
   module Gml
     class EnvelopeWithTimePeriod < Lutaml::Model::Serializable

--- a/lib/ogc/gml/face.rb
+++ b/lib/ogc/gml/face.rb
@@ -2,16 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "directed_edge_property"
-require_relative "directed_topo_solid_property"
-require_relative "meta_data_property"
-require_relative "node_property"
-require_relative "reference"
-require_relative "surface_property"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class Face < Lutaml::Model::Serializable

--- a/lib/ogc/gml/face_or_topo_solid_property.rb
+++ b/lib/ogc/gml/face_or_topo_solid_property.rb
@@ -2,14 +2,8 @@
 
 require "lutaml/model"
 
-# require_relative "face"
-# require_relative "topo_solid"
-
 module Ogc
   module Gml
-    class Face < Lutaml::Model::Serializable; end
-    class TopoSolid < Lutaml::Model::Serializable; end
-
     class FaceOrTopoSolidProperty < Lutaml::Model::Serializable
       attribute :nil_reason, :string
       attribute :remote_schema, RemoteSchema

--- a/lib/ogc/gml/feature_array_property.rb
+++ b/lib/ogc/gml/feature_array_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_feature"
-
 module Ogc
   module Gml
     class FeatureArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/feature_collection.rb
+++ b/lib/ogc/gml/feature_collection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_feature_collection"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/feature_property.rb
+++ b/lib/ogc/gml/feature_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_feature"
-
 module Ogc
   module Gml
     class FeatureProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/file.rb
+++ b/lib/ogc/gml/file.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "association_role"
-require_relative "code"
-
 module Ogc
   module Gml
     class File < Lutaml::Model::Serializable

--- a/lib/ogc/gml/formula_citation.rb
+++ b/lib/ogc/gml/formula_citation.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "string_or_ref"
-
 module Ogc
   module Gml
     class FormulaCitation < Lutaml::Model::Serializable

--- a/lib/ogc/gml/general_conversion_property.rb
+++ b/lib/ogc/gml/general_conversion_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_general_conversion"
-
 module Ogc
   module Gml
     class GeneralConversionProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/general_transformation_property.rb
+++ b/lib/ogc/gml/general_transformation_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_general_transformation"
-
 module Ogc
   module Gml
     class GeneralTransformationProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/generic_meta_data.rb
+++ b/lib/ogc/gml/generic_meta_data.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "identifier"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/geocentric_crs.rb
+++ b/lib/ogc/gml/geocentric_crs.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "cartesian_cs_property"
-require_relative "geodetic_datum_property"
-require_relative "spherical_cs_property"
-require_relative "abstract_crs"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/geocentric_crs_property.rb
+++ b/lib/ogc/gml/geocentric_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "geocentric_crs"
-
 module Ogc
   module Gml
     class GeocentricCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/geodesic.rb
+++ b/lib/ogc/gml/geodesic.rb
@@ -2,11 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "direct_position_list"
-require_relative "direct_position"
-require_relative "point_property"
-require_relative "abstract_curve_segment"
-
 module Ogc
   module Gml
     class Geodesic < AbstractCurveSegment

--- a/lib/ogc/gml/geodesic_string.rb
+++ b/lib/ogc/gml/geodesic_string.rb
@@ -2,11 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "direct_position_list"
-require_relative "direct_position"
-require_relative "point_property"
-require_relative "abstract_curve_segment"
-
 module Ogc
   module Gml
     class GeodesicString < AbstractCurveSegment

--- a/lib/ogc/gml/geodetic_crs.rb
+++ b/lib/ogc/gml/geodetic_crs.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "cartesian_cs_property"
-require_relative "ellipsoidal_cs_property"
-require_relative "geodetic_datum_property"
-require_relative "spherical_cs_property"
-require_relative "abstract_crs"
-
 module Ogc
   module Gml
     class GeodeticCRS < AbstractCRS

--- a/lib/ogc/gml/geodetic_crs_property.rb
+++ b/lib/ogc/gml/geodetic_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "geodetic_crs"
-
 module Ogc
   module Gml
     class GeodeticCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/geodetic_datum.rb
+++ b/lib/ogc/gml/geodetic_datum.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "ellipsoid_property"
-require_relative "prime_meridian_property"
-require_relative "abstract_datum"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/geodetic_datum_property.rb
+++ b/lib/ogc/gml/geodetic_datum_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "geodetic_datum"
-
 module Ogc
   module Gml
     class GeodeticDatumProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/geographic_crs.rb
+++ b/lib/ogc/gml/geographic_crs.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "ellipsoidal_cs_property"
-require_relative "geodetic_datum_property"
-require_relative "abstract_crs"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/geographic_crs_property.rb
+++ b/lib/ogc/gml/geographic_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "geographic_crs"
-
 module Ogc
   module Gml
     class GeographicCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/geometric_complex.rb
+++ b/lib/ogc/gml/geometric_complex.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "geometric_primitive_property"
-require_relative "abstract_geometric_aggregate"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/geometric_primitive_property.rb
+++ b/lib/ogc/gml/geometric_primitive_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_geometric_primitive"
-
 module Ogc
   module Gml
     class GeometricPrimitiveProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/geometry_array_property.rb
+++ b/lib/ogc/gml/geometry_array_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_geometry"
-
 module Ogc
   module Gml
     class GeometryArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/geometry_property.rb
+++ b/lib/ogc/gml/geometry_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_geometry"
-
 module Ogc
   module Gml
     class GeometryProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/grid.rb
+++ b/lib/ogc/gml/grid.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "grid_limits"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class Grid < Lutaml::Model::Serializable

--- a/lib/ogc/gml/grid_function.rb
+++ b/lib/ogc/gml/grid_function.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "sequence_rule"
-
 module Ogc
   module Gml
     class GridFunction < Lutaml::Model::Serializable

--- a/lib/ogc/gml/grid_limits.rb
+++ b/lib/ogc/gml/grid_limits.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "grid_envelope"
-
 module Ogc
   module Gml
     class GridLimits < Lutaml::Model::Serializable

--- a/lib/ogc/gml/history_property.rb
+++ b/lib/ogc/gml/history_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_time_slice"
-
 module Ogc
   module Gml
     class HistoryProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/image_crs.rb
+++ b/lib/ogc/gml/image_crs.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "affine_cs_property"
-require_relative "cartesian_cs_property"
-require_relative "image_datum_property"
-require_relative "oblique_cartesian_cs_property"
-require_relative "abstract_crs"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/image_crs_property.rb
+++ b/lib/ogc/gml/image_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "image_crs"
-
 module Ogc
   module Gml
     class ImageCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/image_datum.rb
+++ b/lib/ogc/gml/image_datum.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_datum"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/image_datum_property.rb
+++ b/lib/ogc/gml/image_datum_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "image_datum"
-
 module Ogc
   module Gml
     class ImageDatumProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/indirect_entry.rb
+++ b/lib/ogc/gml/indirect_entry.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "definition_proxy"
-
 module Ogc
   module Gml
     class IndirectEntry < Lutaml::Model::Serializable

--- a/lib/ogc/gml/knot_property.rb
+++ b/lib/ogc/gml/knot_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "knot"
-
 module Ogc
   module Gml
     class KnotProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/length.rb
+++ b/lib/ogc/gml/length.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "measure"
-require_relative "unit_of_measure"
-
 module Ogc
   module Gml
     class Length < UnitOfMeasure

--- a/lib/ogc/gml/line_string.rb
+++ b/lib/ogc/gml/line_string.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinates"
-require_relative "direct_position_list"
-require_relative "direct_position"
-require_relative "point_property"
-require_relative "abstract_geometry"
-
 module Ogc
   module Gml
     class LineString < AbstractGeometry

--- a/lib/ogc/gml/line_string_segment.rb
+++ b/lib/ogc/gml/line_string_segment.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinates"
-require_relative "direct_position_list"
-require_relative "direct_position"
-require_relative "point_property"
-require_relative "abstract_curve_segment"
-
 module Ogc
   module Gml
     class LineStringSegment < AbstractCurveSegment

--- a/lib/ogc/gml/line_string_segment_array_property.rb
+++ b/lib/ogc/gml/line_string_segment_array_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "line_string_segment"
-
 module Ogc
   module Gml
     class LineStringSegmentArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/linear_cs.rb
+++ b/lib/ogc/gml/linear_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/linear_cs_property.rb
+++ b/lib/ogc/gml/linear_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "linear_cs"
-
 module Ogc
   module Gml
     class LinearCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/linear_ring.rb
+++ b/lib/ogc/gml/linear_ring.rb
@@ -2,11 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "coordinates"
-require_relative "direct_position_list"
-require_relative "direct_position"
-require_relative "point_property"
-
 module Ogc
   module Gml
     class LinearRing < Lutaml::Model::Serializable

--- a/lib/ogc/gml/location_property.rb
+++ b/lib/ogc/gml/location_property.rb
@@ -2,10 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_geometry"
-require_relative "code"
-require_relative "string_or_ref"
-
 module Ogc
   module Gml
     class LocationProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/mapping_rule.rb
+++ b/lib/ogc/gml/mapping_rule.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "reference"
-
 module Ogc
   module Gml
     class MappingRule < Lutaml::Model::Serializable

--- a/lib/ogc/gml/meta_data_property.rb
+++ b/lib/ogc/gml/meta_data_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_meta_data"
-
 module Ogc
   module Gml
     class MetaDataProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/moving_object_status.rb
+++ b/lib/ogc/gml/moving_object_status.rb
@@ -2,18 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "direct_position"
-require_relative "direction_property"
-require_relative "geometry_property"
-require_relative "location_property"
-require_relative "measure"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "abstract_time_complex"
-
 module Ogc
   module Gml
     class MovingObjectStatus < AbstractTimeComplex

--- a/lib/ogc/gml/multi_curve.rb
+++ b/lib/ogc/gml/multi_curve.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "curve_array_property"
-require_relative "composite_curve"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/multi_curve_property.rb
+++ b/lib/ogc/gml/multi_curve_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "multi_curve"
-
 module Ogc
   module Gml
     class MultiCurveProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/multi_geometry.rb
+++ b/lib/ogc/gml/multi_geometry.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "geometry_array_property"
-require_relative "geometry_property"
-require_relative "abstract_geometric_aggregate"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/multi_geometry_property.rb
+++ b/lib/ogc/gml/multi_geometry_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_geometric_aggregate"
-
 module Ogc
   module Gml
     class MultiGeometryProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/multi_point.rb
+++ b/lib/ogc/gml/multi_point.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "point_array_property"
-require_relative "point_property"
-require_relative "abstract_geometric_aggregate"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/multi_point_property.rb
+++ b/lib/ogc/gml/multi_point_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "multi_point"
-
 module Ogc
   module Gml
     class MultiPointProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/multi_solid.rb
+++ b/lib/ogc/gml/multi_solid.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_geometric_aggregate"
-require_relative "solid_array_property"
-require_relative "solid_property"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/multi_solid_property.rb
+++ b/lib/ogc/gml/multi_solid_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "multi_solid"
-
 module Ogc
   module Gml
     class MultiSolidProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/multi_surface.rb
+++ b/lib/ogc/gml/multi_surface.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_geometric_aggregate"
-require_relative "surface_array_property"
-require_relative "surface_property"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/multi_surface_property.rb
+++ b/lib/ogc/gml/multi_surface_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "multi_surface"
-
 module Ogc
   module Gml
     class MultiSurfaceProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/namespace.rb
+++ b/lib/ogc/gml/namespace.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "namespaces/gml_32_namespace"
-require_relative "namespaces/gml_31_namespace"
-
 module Ogc
   module Gml
     # Default namespace for GML 3.2

--- a/lib/ogc/gml/node.rb
+++ b/lib/ogc/gml/node.rb
@@ -2,20 +2,8 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "directed_edge_property"
-require_relative "face_or_topo_solid_property"
-require_relative "meta_data_property"
-require_relative "point_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
-    class DirectedEdgeProperty < Lutaml::Model::Serializable
-    end
-
     class Node < Lutaml::Model::Serializable
       attribute :id, Identifier
       attribute :aggregation_type, :string

--- a/lib/ogc/gml/node_or_edge_property.rb
+++ b/lib/ogc/gml/node_or_edge_property.rb
@@ -2,14 +2,8 @@
 
 require "lutaml/model"
 
-# require_relative "edge"
-require_relative "node"
-
 module Ogc
   module Gml
-    class Edge < Lutaml::Model::Serializable
-    end
-
     class NodeOrEdgeProperty < Lutaml::Model::Serializable
       attribute :nil_reason, :string
       attribute :remote_schema, RemoteSchema

--- a/lib/ogc/gml/node_property.rb
+++ b/lib/ogc/gml/node_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "node"
-
 module Ogc
   module Gml
     class NodeProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/oblique_cartesian_cs.rb
+++ b/lib/ogc/gml/oblique_cartesian_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/oblique_cartesian_cs_property.rb
+++ b/lib/ogc/gml/oblique_cartesian_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "oblique_cartesian_cs"
-
 module Ogc
   module Gml
     class ObliqueCartesianCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/observation.rb
+++ b/lib/ogc/gml/observation.rb
@@ -2,18 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "bounding_shape"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "location_property"
-require_relative "meta_data_property"
-require_relative "procedure_property"
-require_relative "reference"
-require_relative "result"
-require_relative "target_property"
-require_relative "time_primitive_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class Observation < AbstractTopology

--- a/lib/ogc/gml/offset_curve.rb
+++ b/lib/ogc/gml/offset_curve.rb
@@ -2,11 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "curve_property"
-require_relative "length"
-require_relative "vector"
-require_relative "abstract_curve_segment"
-
 module Ogc
   module Gml
     class OffsetCurve < AbstractCurveSegment

--- a/lib/ogc/gml/operation_method.rb
+++ b/lib/ogc/gml/operation_method.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_general_operation_parameter_property"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "formula_citation"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class OperationMethod < AbstractTopology

--- a/lib/ogc/gml/operation_method_property.rb
+++ b/lib/ogc/gml/operation_method_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "operation_method"
-
 module Ogc
   module Gml
     class OperationMethodProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/operation_parameter.rb
+++ b/lib/ogc/gml/operation_parameter.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_general_operation_parameter"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/operation_parameter_group.rb
+++ b/lib/ogc/gml/operation_parameter_group.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_general_operation_parameter_property"
-require_relative "abstract_general_operation_parameter"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/operation_parameter_group_property.rb
+++ b/lib/ogc/gml/operation_parameter_group_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "operation_parameter_group"
-
 module Ogc
   module Gml
     class OperationParameterGroupProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/operation_parameter_property.rb
+++ b/lib/ogc/gml/operation_parameter_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "operation_parameter"
-
 module Ogc
   module Gml
     class OperationParameterProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/operation_property.rb
+++ b/lib/ogc/gml/operation_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_coordinate_operation"
-
 module Ogc
   module Gml
     class OperationProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/orientable_curve.rb
+++ b/lib/ogc/gml/orientable_curve.rb
@@ -2,18 +2,8 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-# require_relative "curve_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
-    class CurveProperty < Lutaml::Model::Serializable
-    end
-
     class OrientableCurve < Lutaml::Model::Serializable
       attribute :id, Identifier
       attribute :srs_name, :string

--- a/lib/ogc/gml/orientable_surface.rb
+++ b/lib/ogc/gml/orientable_surface.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "surface_property"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class OrientableSurface < Lutaml::Model::Serializable

--- a/lib/ogc/gml/parameter_value.rb
+++ b/lib/ogc/gml/parameter_value.rb
@@ -2,11 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "dms_angle"
-require_relative "measure_list"
-require_relative "measure"
-require_relative "operation_parameter_property"
-
 module Ogc
   module Gml
     class ParameterValue < Lutaml::Model::Serializable

--- a/lib/ogc/gml/parameter_value_group.rb
+++ b/lib/ogc/gml/parameter_value_group.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_general_parameter_value_property"
-require_relative "reference"
-
 module Ogc
   module Gml
     class ParameterValueGroup < Lutaml::Model::Serializable

--- a/lib/ogc/gml/pass_through_operation.rb
+++ b/lib/ogc/gml/pass_through_operation.rb
@@ -2,15 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "coordinate_operation_accuracy"
-require_relative "coordinate_operation_property"
-require_relative "crs_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "concatenated_operation"
-
 module Ogc
   module Gml
     class PassThroughOperation < ConcatenatedOperation

--- a/lib/ogc/gml/pass_through_operation_property.rb
+++ b/lib/ogc/gml/pass_through_operation_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "pass_through_operation"
-
 module Ogc
   module Gml
     class PassThroughOperationProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/point.rb
+++ b/lib/ogc/gml/point.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "direct_position"
-require_relative "abstract_geometry"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/point_array_property.rb
+++ b/lib/ogc/gml/point_array_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "point"
-
 module Ogc
   module Gml
     class PointArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/point_property.rb
+++ b/lib/ogc/gml/point_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "point"
-
 module Ogc
   module Gml
     class PointProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/polar_cs.rb
+++ b/lib/ogc/gml/polar_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/polar_cs_property.rb
+++ b/lib/ogc/gml/polar_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "polar_cs"
-
 module Ogc
   module Gml
     class PolarCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/polygon.rb
+++ b/lib/ogc/gml/polygon.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "reference"
-require_relative "shell_property"
-require_relative "abstract_geometry"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/polygon_patch.rb
+++ b/lib/ogc/gml/polygon_patch.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "shell_property"
-
 module Ogc
   module Gml
     class PolygonPatch < Lutaml::Model::Serializable

--- a/lib/ogc/gml/prime_meridian.rb
+++ b/lib/ogc/gml/prime_meridian.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "angle"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class PrimeMeridian < AbstractTopology

--- a/lib/ogc/gml/prime_meridian_property.rb
+++ b/lib/ogc/gml/prime_meridian_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "prime_meridian"
-
 module Ogc
   module Gml
     class PrimeMeridianProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/priority_location_property.rb
+++ b/lib/ogc/gml/priority_location_property.rb
@@ -2,10 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_geometry"
-require_relative "code"
-require_relative "string_or_ref"
-
 module Ogc
   module Gml
     class PriorityLocationProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/procedure_property.rb
+++ b/lib/ogc/gml/procedure_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_feature"
-
 module Ogc
   module Gml
     class ProcedureProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/projected_crs.rb
+++ b/lib/ogc/gml/projected_crs.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "cartesian_cs_property"
-require_relative "geodetic_crs_property"
-require_relative "geographic_crs_property"
-require_relative "abstract_general_derived_crs"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/projected_crs_property.rb
+++ b/lib/ogc/gml/projected_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "projected_crs"
-
 module Ogc
   module Gml
     class ProjectedCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/quantity.rb
+++ b/lib/ogc/gml/quantity.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "measure"
-
 module Ogc
   module Gml
     class Quantity < Lutaml::Model::Serializable

--- a/lib/ogc/gml/quantity_extent.rb
+++ b/lib/ogc/gml/quantity_extent.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "measure_or_nil_reason_list"
-
 module Ogc
   module Gml
     class QuantityExtent < Lutaml::Model::Serializable

--- a/lib/ogc/gml/range_set.rb
+++ b/lib/ogc/gml/range_set.rb
@@ -2,10 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "data_block"
-require_relative "file"
-require_relative "value_array"
-
 module Ogc
   module Gml
     class RangeSet < Lutaml::Model::Serializable

--- a/lib/ogc/gml/rectangle.rb
+++ b/lib/ogc/gml/rectangle.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "shell_property"
-
 module Ogc
   module Gml
     class Rectangle < Lutaml::Model::Serializable

--- a/lib/ogc/gml/rectified_grid.rb
+++ b/lib/ogc/gml/rectified_grid.rb
@@ -2,15 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "grid_limits"
-require_relative "meta_data_property"
-require_relative "point_property"
-require_relative "reference"
-require_relative "vector"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class RectifiedGrid < Lutaml::Model::Serializable

--- a/lib/ogc/gml/ref_location.rb
+++ b/lib/ogc/gml/ref_location.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "affine_placement"
-
 module Ogc
   module Gml
     class RefLocation < Lutaml::Model::Serializable

--- a/lib/ogc/gml/related_time.rb
+++ b/lib/ogc/gml/related_time.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_time_primitive"
-
 module Ogc
   module Gml
     class RelatedTime < Lutaml::Model::Serializable

--- a/lib/ogc/gml/ring.rb
+++ b/lib/ogc/gml/ring.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "composite_curve"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/second_defining_parameter1.rb
+++ b/lib/ogc/gml/second_defining_parameter1.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "second_defining_parameter2"
-
 module Ogc
   module Gml
     class SecondDefiningParameter1 < Lutaml::Model::Serializable

--- a/lib/ogc/gml/second_defining_parameter2.rb
+++ b/lib/ogc/gml/second_defining_parameter2.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "length"
-require_relative "measure"
-
 module Ogc
   module Gml
     class SecondDefiningParameter2 < Lutaml::Model::Serializable

--- a/lib/ogc/gml/shell.rb
+++ b/lib/ogc/gml/shell.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "surface_property"
 
 module Ogc
   module Gml
-    class SurfaceProperty < Lutaml::Model::Serializable
-    end
-
     class Shell < Lutaml::Model::Serializable
       attribute :aggregation_type, :string
       attribute :surface_member, SurfaceProperty, collection: true

--- a/lib/ogc/gml/shell_property.rb
+++ b/lib/ogc/gml/shell_property.rb
@@ -2,10 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "shell"
-require_relative "ring"
-require_relative "linear_ring"
-
 module Ogc
   module Gml
     class ShellProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/single_crs_property.rb
+++ b/lib/ogc/gml/single_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_crs"
-
 module Ogc
   module Gml
     class SingleCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/single_operation_property.rb
+++ b/lib/ogc/gml/single_operation_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_coordinate_operation"
-
 module Ogc
   module Gml
     class SingleOperationProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/solid.rb
+++ b/lib/ogc/gml/solid.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_solid"
-require_relative "shell_property"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/solid_array_property.rb
+++ b/lib/ogc/gml/solid_array_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_solid"
-
 module Ogc
   module Gml
     class SolidArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/solid_property.rb
+++ b/lib/ogc/gml/solid_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_solid"
-
 module Ogc
   module Gml
     class SolidProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/sphere.rb
+++ b/lib/ogc/gml/sphere.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "cylinder"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/spherical_cs.rb
+++ b/lib/ogc/gml/spherical_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/spherical_cs_property.rb
+++ b/lib/ogc/gml/spherical_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "spherical_cs"
-
 module Ogc
   module Gml
     class SphericalCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/surface.rb
+++ b/lib/ogc/gml/surface.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_surface"
-require_relative "surface_patch_array_property"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/surface_array_property.rb
+++ b/lib/ogc/gml/surface_array_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_surface"
-
 module Ogc
   module Gml
     class SurfaceArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/surface_patch_array_property.rb
+++ b/lib/ogc/gml/surface_patch_array_property.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_surface_patch"
-require_relative "triangle"
-
 module Ogc
   module Gml
     class SurfacePatchArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/surface_property.rb
+++ b/lib/ogc/gml/surface_property.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_surface"
-require_relative "polygon"
-
 module Ogc
   module Gml
     class SurfaceProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/target_property.rb
+++ b/lib/ogc/gml/target_property.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_feature"
-require_relative "abstract_geometry"
-
 module Ogc
   module Gml
     class TargetProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/temporal_crs.rb
+++ b/lib/ogc/gml/temporal_crs.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "temporal_cs_property"
-require_relative "temporal_datum_property"
-require_relative "time_cs_property"
-require_relative "abstract_topology"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/temporal_crs_property.rb
+++ b/lib/ogc/gml/temporal_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "temporal_crs"
-
 module Ogc
   module Gml
     class TemporalCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/temporal_cs.rb
+++ b/lib/ogc/gml/temporal_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/temporal_cs_property.rb
+++ b/lib/ogc/gml/temporal_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "temporal_cs"
-
 module Ogc
   module Gml
     class TemporalCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/temporal_datum.rb
+++ b/lib/ogc/gml/temporal_datum.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "time_instant_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class TemporalDatum < AbstractTopology

--- a/lib/ogc/gml/temporal_datum_property.rb
+++ b/lib/ogc/gml/temporal_datum_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "temporal_datum"
-
 module Ogc
   module Gml
     class TemporalDatumProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_calendar.rb
+++ b/lib/ogc/gml/time_calendar.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "time_calendar_era_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class TimeCalendar < AbstractTopology

--- a/lib/ogc/gml/time_calendar_era.rb
+++ b/lib/ogc/gml/time_calendar_era.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "time_period_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class TimeCalendarEra < AbstractTopology

--- a/lib/ogc/gml/time_calendar_era_property.rb
+++ b/lib/ogc/gml/time_calendar_era_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "time_calendar_era"
-
 module Ogc
   module Gml
     class TimeCalendarEraProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_calendar_property.rb
+++ b/lib/ogc/gml/time_calendar_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "time_calendar"
-
 module Ogc
   module Gml
     class TimeCalendarProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_clock.rb
+++ b/lib/ogc/gml/time_clock.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "time_calendar_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class TimeClock < AbstractTopology

--- a/lib/ogc/gml/time_coordinate_system.rb
+++ b/lib/ogc/gml/time_coordinate_system.rb
@@ -2,15 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "time_instant_property"
-require_relative "time_interval_length"
-require_relative "time_position"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class TimeCoordinateSystem < AbstractTopology

--- a/lib/ogc/gml/time_cs.rb
+++ b/lib/ogc/gml/time_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/time_cs_property.rb
+++ b/lib/ogc/gml/time_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "time_cs"
-
 module Ogc
   module Gml
     class TimeCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_edge.rb
+++ b/lib/ogc/gml/time_edge.rb
@@ -2,15 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "related_time"
-require_relative "time_node_property"
-require_relative "time_period_property"
-require_relative "abstract_time_topology_primitive"
-
 module Ogc
   module Gml
     class TimeEdge < AbstractTimeTopologyPrimitive

--- a/lib/ogc/gml/time_edge_property.rb
+++ b/lib/ogc/gml/time_edge_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "time_edge"
-
 module Ogc
   module Gml
     class TimeEdgeProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_instant.rb
+++ b/lib/ogc/gml/time_instant.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_time_geometric_primitive"
-require_relative "time_position"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/time_instant_property.rb
+++ b/lib/ogc/gml/time_instant_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "time_instant"
-
 module Ogc
   module Gml
     class TimeInstantProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_node.rb
+++ b/lib/ogc/gml/time_node.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-# require_relative "time_edge_property"
-require_relative "time_instant_property"
-require_relative "abstract_time_topology_primitive"
 
 module Ogc
   module Gml
-    class TimeEdgeProperty < Lutaml::Model::Serializable
-    end
-
     class TimeNode < AbstractTimeTopologyPrimitive
       attribute :previous_edge, TimeEdgeProperty, collection: true
       attribute :next_edge, TimeEdgeProperty, collection: true

--- a/lib/ogc/gml/time_node_property.rb
+++ b/lib/ogc/gml/time_node_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "time_node"
-
 module Ogc
   module Gml
     class TimeNodeProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_ordinal_era.rb
+++ b/lib/ogc/gml/time_ordinal_era.rb
@@ -1,18 +1,9 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "reference"
-require_relative "related_time"
-require_relative "time_node_property"
-# require_relative "time_ordinal_era_property"
-require_relative "time_period_property"
-require_relative "abstract_topology"
 
 module Ogc
   module Gml
-    class TimeOrdinalEraProperty < Lutaml::Model::Serializable
-    end
-
     class TimeOrdinalEra < AbstractTopology
       attribute :remarks, :string
       attribute :related_time, RelatedTime, collection: true

--- a/lib/ogc/gml/time_ordinal_era_property.rb
+++ b/lib/ogc/gml/time_ordinal_era_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "time_ordinal_era"
-
 module Ogc
   module Gml
     class TimeOrdinalEraProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_ordinal_reference_system.rb
+++ b/lib/ogc/gml/time_ordinal_reference_system.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "time_ordinal_era_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class TimeOrdinalReferenceSystem < AbstractTopology

--- a/lib/ogc/gml/time_period.rb
+++ b/lib/ogc/gml/time_period.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "time_instant_property"
-require_relative "time_interval_length"
-require_relative "time_position"
-require_relative "abstract_time_geometric_primitive"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/time_period_property.rb
+++ b/lib/ogc/gml/time_period_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "time_period"
-
 module Ogc
   module Gml
     class TimePeriodProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_primitive_property.rb
+++ b/lib/ogc/gml/time_primitive_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_time_primitive"
-
 module Ogc
   module Gml
     class TimePrimitiveProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/time_reference_system.rb
+++ b/lib/ogc/gml/time_reference_system.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class TimeReferenceSystem < AbstractTopology

--- a/lib/ogc/gml/time_topology_complex.rb
+++ b/lib/ogc/gml/time_topology_complex.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "time_topology_primitive_property"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class TimeTopologyComplex < AbstractTopology

--- a/lib/ogc/gml/time_topology_primitive_property.rb
+++ b/lib/ogc/gml/time_topology_primitive_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_time_topology_primitive"
-
 module Ogc
   module Gml
     class TimeTopologyPrimitiveProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/tin.rb
+++ b/lib/ogc/gml/tin.rb
@@ -2,12 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "control_point"
-require_relative "length"
-require_relative "line_string_segment_array_property"
-require_relative "surface_patch_array_property"
-require_relative "abstract_geometry"
-
 module Ogc
   module Gml
     class Tin < AbstractGeometry

--- a/lib/ogc/gml/topo_complex.rb
+++ b/lib/ogc/gml/topo_complex.rb
@@ -2,20 +2,8 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-# require_relative "topo_complex_property"
-require_relative "topo_primitive_array_association"
-require_relative "topo_primitive_member"
-require_relative "identifier"
-
 module Ogc
   module Gml
-    class TopoComplexProperty < Lutaml::Model::Serializable
-    end
-
     class TopoComplex < Lutaml::Model::Serializable
       attribute :id, Identifier
       attribute :is_maximal, :boolean, default: -> { false }

--- a/lib/ogc/gml/topo_complex_property.rb
+++ b/lib/ogc/gml/topo_complex_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "topo_complex"
-
 module Ogc
   module Gml
     class TopoComplexProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_curve.rb
+++ b/lib/ogc/gml/topo_curve.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "directed_edge_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class TopoCurve < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_curve_property.rb
+++ b/lib/ogc/gml/topo_curve_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "topo_curve"
-
 module Ogc
   module Gml
     class TopoCurveProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_point.rb
+++ b/lib/ogc/gml/topo_point.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "directed_node_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class TopoPoint < AbstractTopology

--- a/lib/ogc/gml/topo_point_property.rb
+++ b/lib/ogc/gml/topo_point_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "topo_point"
-
 module Ogc
   module Gml
     class TopoPointProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_primitive_array_association.rb
+++ b/lib/ogc/gml/topo_primitive_array_association.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_topo_primitive"
-
 module Ogc
   module Gml
     class TopoPrimitiveArrayAssociation < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_primitive_member.rb
+++ b/lib/ogc/gml/topo_primitive_member.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_topo_primitive"
-
 module Ogc
   module Gml
     class TopoPrimitiveMember < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_solid.rb
+++ b/lib/ogc/gml/topo_solid.rb
@@ -2,20 +2,8 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-# require_relative "directed_face_property"
-require_relative "meta_data_property"
-require_relative "node_or_edge_property"
-require_relative "reference"
-require_relative "solid_property"
-require_relative "identifier"
-
 module Ogc
   module Gml
-    class DirectedFaceProperty < Lutaml::Model::Serializable
-    end
-
     class TopoSolid < Lutaml::Model::Serializable
       attribute :id, Identifier
       attribute :aggregation_type, :string

--- a/lib/ogc/gml/topo_solid_property.rb
+++ b/lib/ogc/gml/topo_solid_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "topo_solid"
-
 module Ogc
   module Gml
     class TopoSolidProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_surface.rb
+++ b/lib/ogc/gml/topo_surface.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "directed_face_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class TopoSurface < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_surface_property.rb
+++ b/lib/ogc/gml/topo_surface_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "topo_surface"
-
 module Ogc
   module Gml
     class TopoSurfaceProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_volume.rb
+++ b/lib/ogc/gml/topo_volume.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "directed_topo_solid_property"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class TopoVolume < Lutaml::Model::Serializable

--- a/lib/ogc/gml/topo_volume_property.rb
+++ b/lib/ogc/gml/topo_volume_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "topo_volume"
-
 module Ogc
   module Gml
     class TopoVolumeProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/transformation.rb
+++ b/lib/ogc/gml/transformation.rb
@@ -2,16 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_general_parameter_value_property"
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "coordinate_operation_accuracy"
-require_relative "crs_property"
-require_relative "meta_data_property"
-require_relative "operation_method_property"
-require_relative "reference"
-require_relative "abstract_general_transformation"
-
 module Ogc
   module Gml
     class Transformation < AbstractGeneralTransformation

--- a/lib/ogc/gml/transformation_property.rb
+++ b/lib/ogc/gml/transformation_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "transformation"
-
 module Ogc
   module Gml
     class TransformationProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/triangle.rb
+++ b/lib/ogc/gml/triangle.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "shell_property"
-
 module Ogc
   module Gml
     class Triangle < Lutaml::Model::Serializable

--- a/lib/ogc/gml/unit_definition.rb
+++ b/lib/ogc/gml/unit_definition.rb
@@ -2,13 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "string_or_ref"
-require_relative "abstract_topology"
-
 module Ogc
   module Gml
     class UnitDefinition < AbstractTopology

--- a/lib/ogc/gml/user_defined_cs.rb
+++ b/lib/ogc/gml/user_defined_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/user_defined_cs_property.rb
+++ b/lib/ogc/gml/user_defined_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "user_defined_cs"
-
 module Ogc
   module Gml
     class UserDefinedCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/value_array.rb
+++ b/lib/ogc/gml/value_array.rb
@@ -2,14 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "code"
-require_relative "code_with_authority"
-require_relative "meta_data_property"
-require_relative "reference"
-require_relative "value_array_property"
-require_relative "value_property"
-require_relative "identifier"
-
 module Ogc
   module Gml
     class ValueArray < Lutaml::Model::Serializable

--- a/lib/ogc/gml/value_array_property.rb
+++ b/lib/ogc/gml/value_array_property.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_geometry"
-require_relative "abstract_time_object"
-
 module Ogc
   module Gml
     class ValueArrayProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/value_property.rb
+++ b/lib/ogc/gml/value_property.rb
@@ -2,9 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "abstract_geometry"
-require_relative "abstract_time_object"
-
 module Ogc
   module Gml
     class ValueProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/vector.rb
+++ b/lib/ogc/gml/vector.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "direct_position"
-
 module Ogc
   module Gml
     class Vector < Lutaml::Model::Serializable

--- a/lib/ogc/gml/vertical_crs.rb
+++ b/lib/ogc/gml/vertical_crs.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "vertical_cs_property"
-require_relative "vertical_datum_property"
-require_relative "abstract_crs"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/vertical_crs_property.rb
+++ b/lib/ogc/gml/vertical_crs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "vertical_crs"
-
 module Ogc
   module Gml
     class VerticalCRSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/vertical_cs.rb
+++ b/lib/ogc/gml/vertical_cs.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_coordinate_system"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/vertical_cs_property.rb
+++ b/lib/ogc/gml/vertical_cs_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "vertical_cs"
-
 module Ogc
   module Gml
     class VerticalCSProperty < Lutaml::Model::Serializable

--- a/lib/ogc/gml/vertical_datum.rb
+++ b/lib/ogc/gml/vertical_datum.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "lutaml/model"
-require_relative "abstract_datum"
 
 module Ogc
   module Gml

--- a/lib/ogc/gml/vertical_datum_property.rb
+++ b/lib/ogc/gml/vertical_datum_property.rb
@@ -2,8 +2,6 @@
 
 require "lutaml/model"
 
-require_relative "vertical_datum"
-
 module Ogc
   module Gml
     class VerticalDatumProperty < Lutaml::Model::Serializable


### PR DESCRIPTION
## Summary

Replaces the eager `require_relative` graph with `autoload`, fixing the circular-require warnings reported downstream (issue #21):

- `lib/ogc/gml.rb` registers **330 autoload entries** instead of 331 `require_relative` lines; per-file internal `require_relative` calls are stripped.
- Removes the 12 hand-patched cycle-dodges this unblocked: empty shell/stub definitions of `Face`, `TopoSolid`, `Edge`, `Node`-embedded `DirectedEdgeProperty`, `Shell`-embedded `SurfaceProperty`, `RemoteSchema`, `RelatedTime`, `CurveProperty`, `DirectedFaceProperty`, `TimeEdgeProperty`, `TimeOrdinalEraProperty`, `TopoComplexProperty`, plus their commented-out `require_relative` lines. All were content-free (verified empty bodies) — canonical files define the real classes.
- Net: ~1,050 fewer lines, lazy loading, no cycles.

## Why the shells had to go

Under eager alphabetical requires, `class Face < ...; end` shells in other files were order-tolerant no-ops. Under autoload they are landmines: e.g. `node.rb` opened its embedded `DirectedEdgeProperty` shell *before* `class Node`, so the cycle `Node → DirectedEdgeProperty → Edge → TopoSolidProperty → TopoSolid → NodeOrEdgeProperty → Node` returned to a `Node` whose defining class keyword had never executed — `NameError`. One class per file, opened first, lets every cycle close through an already-open class (verified by load test of `Face`, `TopoComplex`, `Shell`, `TopoSolid`, etc.).

## Verification

- Load test of cycle-prone constants passes (`Ogc::Gml::Face`, `TopoComplex`, `Shell`, `Namespace`, `Gml31Namespace`, ...)
- Full suite green, `rubocop` clean across all 347 inspected files
- `ruby -w` circular-require warnings from ogc-gml: 6 → 0 (the 3 that remain with `-w` originate inside lutaml-model itself — `key_value.rb` ↔ `model.rb` — a separate upstream issue)

## Notes

- Loading is now lazy: `require "ogc/gml"` defines the module and registers autoloads; classes materialize on first reference.
- The generator should adopt this layout (one class per file, no intra-file requires) so regeneration doesn't reintroduce the graph; the same change benefits other schema-generated gems with mutually recursive types. Longer term, lazy/string type references in lutaml-model would remove even the need to order class opening.
- Stacked on #24 — merge that first.
